### PR TITLE
PPTP-445 Rename packages and tidy app.Routes file

### DIFF
--- a/app/project/build.properties
+++ b/app/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.4.6

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/home/HomeController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/home/HomeController.scala
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.plasticpackagingtax.returns.controllers
+package uk.gov.hmrc.plasticpackagingtax.returns.controllers.home
 
-import javax.inject.{Inject, Singleton}
+import javax.inject.Inject
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.returns.views.html.start_page
+import uk.gov.hmrc.plasticpackagingtax.returns.views.html.home.home_page
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import scala.concurrent.Future
 
-@Singleton
-class StartController @Inject() (mcc: MessagesControllerComponents, startPage: start_page)
+class HomeController @Inject() (mcc: MessagesControllerComponents, homePage: home_page)
     extends FrontendController(mcc) with I18nSupport {
 
-  val displayPage: Action[AnyContent] = Action.async { implicit request =>
-    Future.successful(Ok(startPage()))
-  }
+  def displayPage: Action[AnyContent] =
+    Action.async { implicit request =>
+      Future.successful(Ok(homePage()))
+    }
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/returns/StartController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/returns/StartController.scala
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.plasticpackagingtax.returns.controllers
+package uk.gov.hmrc.plasticpackagingtax.returns.controllers.returns
 
+import javax.inject.{Inject, Singleton}
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.returns.views.html.home_page
+import uk.gov.hmrc.plasticpackagingtax.returns.views.html.returns.start_page
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
-import javax.inject.Inject
 import scala.concurrent.Future
 
-class HomeController @Inject() (mcc: MessagesControllerComponents, homePage: home_page)
+@Singleton
+class StartController @Inject() (mcc: MessagesControllerComponents, startPage: start_page)
     extends FrontendController(mcc) with I18nSupport {
 
-  def displayPage: Action[AnyContent] =
-    Action.async { implicit request =>
-      Future.successful(Ok(homePage()))
-    }
+  val displayPage: Action[AnyContent] = Action.async { implicit request =>
+    Future.successful(Ok(startPage()))
+  }
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/home/home_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/home/home_page.scala.html
@@ -14,8 +14,8 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.plasticpackagingtax.returns.controllers.routes.HomeController
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.html.components.pageTitle
+@import uk.gov.hmrc.plasticpackagingtax.returns.views.html.main_template
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.model.Title
 
 @this(

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/partials/siteHeader.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/partials/siteHeader.scala.html
@@ -17,7 +17,7 @@
 @import uk.gov.hmrc.hmrcfrontend.views.html.components.HmrcHeader
 @import uk.gov.hmrc.hmrcfrontend.views.html.components.Header
 @import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language
-@import uk.gov.hmrc.plasticpackagingtax.returns.controllers.{routes => pptRoutes}
+@import uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.{routes => homeRoutes}
 
 
 @this(hmrcHeader: HmrcHeader)
@@ -28,7 +28,7 @@
 @hmrcHeader(Header(
 homepageUrl = "https://www.gov.uk",
 serviceName = Some(messages("service.name")),
-serviceUrl = pptRoutes.HomeController.displayPage.url,
+serviceUrl = homeRoutes.HomeController.displayPage.url,
 language = language.En,
 containerClasses = "govuk-width-container"
 ))

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/start_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/start_page.scala.html
@@ -17,12 +17,13 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukInsetText
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.model.Title
-@import uk.gov.hmrc.plasticpackagingtax.returns.controllers.{routes => pptRoutes}
+@import uk.gov.hmrc.plasticpackagingtax.returns.controllers.returns.{routes => returnsRoutes}
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.html.components.bulletList
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.html.components.pageTitle
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.html.components.link
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.html.components.sectionHeader
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.html.components.paragraphBody
+@import uk.gov.hmrc.plasticpackagingtax.returns.views.html.main_template
 
 @this(
 govukLayout: main_template,
@@ -84,7 +85,7 @@ govukButton: GovukButton
 
         @govukButton(
             Button(
-                href = Some(pptRoutes.StartController.displayPage().url),
+                href = Some(returnsRoutes.StartController.displayPage().url),
                 isStartButton = true,
                 content = Text(messages("startPage.buttonName"))
             )

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,7 +1,7 @@
 # microservice specific routes
 
+->         /returns                 returns.Routes
+
+->         /home                    home.Routes
+
 GET        /assets/*file            controllers.Assets.versioned(path="/public", file: Asset)
-
-GET        /home                    uk.gov.hmrc.plasticpackagingtax.returns.controllers.HomeController.displayPage
-
-GET        /start                   uk.gov.hmrc.plasticpackagingtax.returns.controllers.StartController.displayPage

--- a/conf/home.routes
+++ b/conf/home.routes
@@ -1,0 +1,3 @@
+# microservice specific routes
+
+GET        /                    uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.HomeController.displayPage()

--- a/conf/returns.routes
+++ b/conf/returns.routes
@@ -1,0 +1,3 @@
+# microservice specific routes
+
+GET        /submit-return   uk.gov.hmrc.plasticpackagingtax.returns.controllers.returns.StartController.displayPage()

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/home/HomeControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/home/HomeControllerSpec.scala
@@ -14,35 +14,35 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.plasticpackagingtax.returns.controllers
+package uk.gov.hmrc.plasticpackagingtax.returns.controllers.home
 
-import akka.http.scaladsl.model.StatusCodes.OK
+import controllers.Assets.OK
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, when}
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import play.api.test.Helpers.status
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.ControllerSpec
-import uk.gov.hmrc.plasticpackagingtax.returns.views.html.start_page
+import uk.gov.hmrc.plasticpackagingtax.returns.views.html.home.home_page
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
-class StartControllerSpec extends ControllerSpec {
+class HomeControllerSpec extends ControllerSpec {
 
   private val mcc        = stubMessagesControllerComponents()
-  private val startPage  = mock[start_page]
-  private val controller = new StartController(mcc, startPage)
+  private val homePage   = mock[home_page]
+  private val controller = new HomeController(mcc, homePage)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
-    when(startPage.apply()(any(), any())).thenReturn(HtmlFormat.empty)
+    when(homePage.apply()(any(), any())).thenReturn(HtmlFormat.empty)
   }
 
   override protected def afterEach(): Unit = {
-    reset(startPage)
+    reset(homePage)
     super.afterEach()
   }
 
-  "Start Controller" should {
+  "HomePage Controller" should {
 
     "return 200" when {
 
@@ -50,7 +50,7 @@ class StartControllerSpec extends ControllerSpec {
 
         val result = controller.displayPage()(getRequest())
 
-        status(result) mustBe OK.intValue
+        status(result) mustBe OK
       }
     }
   }

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/returns/StartControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/returns/StartControllerSpec.scala
@@ -14,35 +14,35 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.plasticpackagingtax.returns.controllers
+package uk.gov.hmrc.plasticpackagingtax.returns.controllers.returns
 
-import controllers.Assets.OK
+import akka.http.scaladsl.model.StatusCodes.OK
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, when}
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import play.api.test.Helpers.status
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.ControllerSpec
+import uk.gov.hmrc.plasticpackagingtax.returns.views.html.returns.start_page
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
-import uk.gov.hmrc.plasticpackagingtax.returns.views.html.home_page
 
-class HomeControllerSpec extends ControllerSpec {
+class StartControllerSpec extends ControllerSpec {
 
   private val mcc        = stubMessagesControllerComponents()
-  private val homePage   = mock[home_page]
-  private val controller = new HomeController(mcc, homePage)
+  private val startPage  = mock[start_page]
+  private val controller = new StartController(mcc, startPage)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
-    when(homePage.apply()(any(), any())).thenReturn(HtmlFormat.empty)
+    when(startPage.apply()(any(), any())).thenReturn(HtmlFormat.empty)
   }
 
   override protected def afterEach(): Unit = {
-    reset(homePage)
+    reset(startPage)
     super.afterEach()
   }
 
-  "HomePage Controller" should {
+  "Start Controller" should {
 
     "return 200" when {
 
@@ -50,7 +50,7 @@ class HomeControllerSpec extends ControllerSpec {
 
         val result = controller.displayPage()(getRequest())
 
-        status(result) mustBe OK
+        status(result) mustBe OK.intValue
       }
     }
   }

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/StartPageViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/StartPageViewSpec.scala
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.plasticpackagingtax.returns.views
+package uk.gov.hmrc.plasticpackagingtax.returns.views.returns
 
 import org.scalatest.matchers.must.Matchers
 import play.api.mvc.{AnyContent, Request}
 import play.api.test.FakeRequest
 import play.twirl.api.Html
 import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.UnitViewSpec
-import uk.gov.hmrc.plasticpackagingtax.returns.views.html.start_page
+import uk.gov.hmrc.plasticpackagingtax.returns.controllers.returns.{routes => returnsRoutes}
+import uk.gov.hmrc.plasticpackagingtax.returns.views.html.returns.start_page
 import uk.gov.hmrc.plasticpackagingtax.returns.views.tags.ViewTest
 import utils.FakeRequestCSRFSupport.CSRFFakeRequest
 
@@ -144,7 +145,7 @@ class StartPageViewSpec extends UnitViewSpec with Matchers {
 
       view.getElementsByClass("govuk-button").first() must containMessage("startPage.buttonName")
       view.getElementsByClass("govuk-button").first() must haveHref(
-        uk.gov.hmrc.plasticpackagingtax.returns.controllers.routes.StartController.displayPage().url
+        returnsRoutes.StartController.displayPage().url
       )
     }
   }


### PR DESCRIPTION
Routes/Packages can soon become messy and this is a better approach.
Obviously the problem here is that Play actually has an opinion/bug on how the routes and controllers are linked and it is better to provide a clear division on routes and controllers underpinned by the same name.

https://github.com/playframework/playframework/issues/6719
