### PR TITLE
PPTP-838 Replace CSS #id .class to style rows

### DIFF
--- a/app/assets/stylesheets/_returns.scss
+++ b/app/assets/stylesheets/_returns.scss
@@ -55,7 +55,11 @@
 .cell--no-border .govuk-table__cell {
   border: none !important;
 }
-#row-border {
+th.govuk-table__header.row-border {
+  border-bottom: 1px solid #b1b4b6 !important;
+}
+
+td.govuk-table__cell.row-border {
   border-bottom: 1px solid #b1b4b6 !important;
 }
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/check_your_return_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/check_your_return_page.scala.html
@@ -122,8 +122,8 @@ paragraphBody:paragraphBody
         @govukTable(Table(
             rows = Seq(
                 taxCalculationRow("returns.checkYourReturnPage.taxLiability.exemptPackaging.label", taxReturn.taxLiability.totalKgExempt.toString, " kg"),
-                taxCalculationRow("returns.checkYourReturnPage.taxLiability.liablePackaging.label", taxReturn.taxLiability.totalKgLiable.toString, " kg","", Map("id" -> "row-border")),
-                taxCalculationRow("returns.checkYourReturnPage.taxLiability.label", s"£${taxReturn.taxLiability.taxDue.toString}", "" ,"", Map("id" -> "row-border"))
+                taxCalculationRow("returns.checkYourReturnPage.taxLiability.liablePackaging.label", taxReturn.taxLiability.totalKgLiable.toString, " kg","row-border"),
+                taxCalculationRow("returns.checkYourReturnPage.taxLiability.label", s"£${taxReturn.taxLiability.taxDue.toString}", "" ,"row-border")
                 ),
             head = Some(Seq(
                 HeadCell(
@@ -149,7 +149,7 @@ paragraphBody:paragraphBody
 
         @govukTable(Table(
             rows = Seq(
-                taxCalculationRow("returns.checkYourReturnPage.totalCredits.creditsRequested.label", s"£${taxReturn.taxLiability.totalCredit.toString}", "", "", Map("id" -> "row-border")),
+                taxCalculationRow("returns.checkYourReturnPage.totalCredits.creditsRequested.label", s"£${taxReturn.taxLiability.totalCredit.toString}", "", "row-border"),
             ),
             head = Some(Seq(
                 HeadCell(


### PR DESCRIPTION
### Description of Work carried through

Some rows require some border lines in order to provide emphasis on the
values of those same rows
In the past we have used the CSS id `#row-border`, this is a problem
because CSS ids have to be unique per page.

This change will transform the `row-order` into a CSS class.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed 
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave
