### PR TITLE
PPTP-1117 : Make "change of circumstances" optional in "view subscrip…

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/subscriptions/PrimaryContactNameController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/subscriptions/PrimaryContactNameController.scala
@@ -89,7 +89,7 @@ class PrimaryContactNameController @Inject() (
         subscription.copy(legalEntityDetails = updatedLegalEntityDetails,
                           primaryContactDetails = updatedPrimaryContactDetails,
                           changeOfCircumstanceDetails =
-                            ChangeOfCircumstanceDetails("Update to details")
+                            Some(ChangeOfCircumstanceDetails("Update to details"))
         )
       SubscriptionUpdateRequest(updatedSubscription)
     }

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/models/subscription/subscriptionDisplay/SubscriptionDisplayResponse.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/models/subscription/subscriptionDisplay/SubscriptionDisplayResponse.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.plasticpackagingtax.returns.models.subscription._
 
 case class SubscriptionDisplayResponse(
   processingDate: String,
-  changeOfCircumstanceDetails: ChangeOfCircumstanceDetails,
+  changeOfCircumstanceDetails: Option[ChangeOfCircumstanceDetails],
   legalEntityDetails: LegalEntityDetails,
   principalPlaceOfBusinessDetails: PrincipalPlaceOfBusinessDetails,
   primaryContactDetails: PrimaryContactDetails,

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/models/subscription/subscriptionUpdate/SubscriptionUpdateRequest.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/models/subscription/subscriptionUpdate/SubscriptionUpdateRequest.scala
@@ -40,7 +40,10 @@ object SubscriptionUpdateRequest {
 
   def apply(subscriptionDisplayResponse: SubscriptionDisplayResponse): SubscriptionUpdateRequest =
     SubscriptionUpdateRequest(
-      changeOfCircumstanceDetails = subscriptionDisplayResponse.changeOfCircumstanceDetails,
+      changeOfCircumstanceDetails =
+        subscriptionDisplayResponse.changeOfCircumstanceDetails.getOrElse {
+          throw new IllegalStateException("Change of circumstance required")
+        },
       legalEntityDetails = subscriptionDisplayResponse.legalEntityDetails,
       principalPlaceOfBusinessDetails = subscriptionDisplayResponse.principalPlaceOfBusinessDetails,
       primaryContactDetails = subscriptionDisplayResponse.primaryContactDetails,

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/base/PptTestData.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/base/PptTestData.scala
@@ -154,8 +154,10 @@ object PptTestData {
   def createSubscriptionDisplayResponse(subscription: Subscription) =
     SubscriptionDisplayResponse(processingDate = "2020-05-05",
                                 changeOfCircumstanceDetails =
-                                  ChangeOfCircumstanceDetails(changeOfCircumstance =
-                                    "update"
+                                  Some(
+                                    ChangeOfCircumstanceDetails(changeOfCircumstance =
+                                      "update"
+                                    )
                                   ),
                                 legalEntityDetails =
                                   subscription.legalEntityDetails,


### PR DESCRIPTION
…tion response"

This will not be set when a subscription is first created.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed 
 - [ ] Required Environment Config has been amended/added - N/A
 - [x] Links to dependencies have been included (BE/FE work) : https://github.com/hmrc/plastic-packaging-tax-returns/pull/30
 - [x] User Acceptance Tests (UAT) were run locally and have passed - PPT return test failed; don't know why and don't have the time to investigate at the moment.
 - [ ] No Accessibility errors/warnings reported by Wave - N/A
