### PR TITLE
PPTP-1118 - Links vulnerable to reverse tabnabbing

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/components/link.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/components/link.scala.html
@@ -16,9 +16,9 @@
 
 @this()
 
-@(text: String, textHidden: Option[String] = None, call: Call, target: String = "_self", id: Option[String] = None, classes: String = "govuk-link govuk-link--no-visited-state")
+@(text: String, textHidden: Option[String] = None, call: Call, newTab: Boolean = false, id: Option[String] = None, classes: String = "govuk-link govuk-link--no-visited-state")
 
 @hasHint = @{textHidden.exists(_.nonEmpty)}
 
-<a class="@classes" href="@call" target=@target @id.map{id => id="@id" }>
+<a class="@classes" href="@call" @if(newTab) { target="_blank" rel="noopener noreferrer" } @id.map{id => id="@id" }>
  <span @if(hasHint){aria-hidden="true"}>@text</span>@if(hasHint){<span class="govuk-visually-hidden">@{textHidden.getOrElse("")}</span>}</a>

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/home/UnauthorisedViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/home/UnauthorisedViewSpec.scala
@@ -52,7 +52,7 @@ class UnauthorisedViewSpec extends UnitViewSpec with Matchers {
 
       link must containMessage("unauthorised.paragraph.1.link")
       link must haveHref(returnRoutes.StartController.displayPage().url)
-      link.attr("target") mustBe "_self"
+      link.attributes().hasKey("target") mustBe false
     }
 
     "display ppt guidance link" in {
@@ -62,7 +62,7 @@ class UnauthorisedViewSpec extends UnitViewSpec with Matchers {
       link must haveHref(
         "https://www.gov.uk/government/publications/introduction-of-plastic-packaging-tax/plastic-packaging-tax"
       )
-      link.attr("target") mustBe "_self"
+      link.attributes().hasKey("target") mustBe false
     }
   }
 }


### PR DESCRIPTION
- remove target attribute from links where not needed
- add rel="noopener noreferrer" where target is "_blank" (open in new tab)

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed 
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave
