### PR TITLE
PPTP-1210 - Update application library dependencies

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/components/govukFlexibleLayout.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/components/govukFlexibleLayout.scala.html
@@ -14,8 +14,7 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.viewmodels.header.Header
-@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.hmrcStandardFooter
+@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcStandardFooter
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.html.partials.siteHeader
 
 @this(
@@ -24,7 +23,7 @@
   govukFooter: GovukFooter,
   govukBackLink: GovukBackLink,
   siteHeader: siteHeader,
-  hmrcFooter: hmrcStandardFooter
+  hmrcFooter: HmrcStandardFooter
 )
 
 @(

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/main_template.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/main_template.scala.html
@@ -22,8 +22,8 @@
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.html.components.timeoutDialog
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.html.components.govukFlexibleLayout
 @import uk.gov.hmrc.plasticpackagingtax.returns.config.TimeoutDialogConfig
-@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.hmrcStandardFooter
 @import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcTrackingConsentSnippet
+@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcStandardFooter
 
 @this(
     govukHeader: GovukHeader,
@@ -35,7 +35,7 @@
     timeoutDialogConfig: TimeoutDialogConfig,
     siteHeader: siteHeader,
     phaseBanner: phaseBanner,
-    hmrcFooter: hmrcStandardFooter,
+    hmrcFooter: HmrcStandardFooter,
     govukFlexibleLayout: govukFlexibleLayout,
 )
 @(title: Title,

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/check_your_return_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/check_your_return_page.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukTable
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.model.Title
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.model.BackButton
@@ -27,7 +26,7 @@
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.html.components.paragraphBody
 
 @this(
-formHelper: formWithCSRF,
+formHelper: FormWithCSRF,
 govukLayout: main_template,
 pageTitle: pageTitle,
 saveButtons: saveButtons,

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/converted_packaging_credit_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/converted_packaging_credit_page.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukInput
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukDetails
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukFieldset
@@ -37,7 +36,7 @@
   paragraphBody: paragraphBody,
   govukDetails : GovukDetails,
   govukFieldset : GovukFieldset,
-  formHelper: formWithCSRF
+  formHelper: FormWithCSRF
 )
 
 @(form: Form[ConvertedPackagingCredit])(implicit request: Request[_], messages: Messages)

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/exported_plastic_weight_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/exported_plastic_weight_page.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukInput
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukDetails
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.model.Title
@@ -35,7 +34,7 @@
   sectionHeader: sectionHeader,
   errorSummary: errorSummary,
   govukDetails : GovukDetails,
-  formHelper: formWithCSRF
+  formHelper: FormWithCSRF
 )
 
 @(form: Form[ExportedPlasticWeight])(implicit request: Request[_], messages: Messages)

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/human_medicines_plastic_weight_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/human_medicines_plastic_weight_page.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukInput
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukDetails
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukFieldset
@@ -37,7 +36,8 @@
   paragraphBody: paragraphBody,
   govukDetails : GovukDetails,
   govukFieldset : GovukFieldset,
-  formHelper: formWithCSRF
+
+  formHelper: FormWithCSRF
 )
 
 @(form: Form[HumanMedicinesPlasticWeight])(implicit request: Request[_], messages: Messages)

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/imported_plastic_weight_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/imported_plastic_weight_page.scala.html
@@ -14,9 +14,7 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukInput
-@import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukDetails
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.model.Title
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.model.BackButton
@@ -36,7 +34,7 @@
   errorSummary: errorSummary,
   paragraphBody: paragraphBody,
   govukDetails : GovukDetails,
-  formHelper: formWithCSRF
+  formHelper: FormWithCSRF
 )
 
 @(form: Form[ImportedPlasticWeight])(implicit request: Request[_], messages: Messages)

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/manufactured_plastic_weight_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/manufactured_plastic_weight_page.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukInput
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukDetails
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.model.Title
@@ -33,7 +32,7 @@
   sectionHeader: sectionHeader,
   errorSummary: errorSummary,
   govukDetails : GovukDetails,
-  formHelper: formWithCSRF
+  formHelper: FormWithCSRF
 )
 
 @(form: Form[ManufacturedPlasticWeight])(implicit request: Request[_], messages: Messages)

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/recycled_plastic_weight_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/recycled_plastic_weight_page.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukInput
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukDetails
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.model.Title
@@ -33,7 +32,7 @@
   sectionHeader: sectionHeader,
   errorSummary: errorSummary,
   govukDetails : GovukDetails,
-  formHelper: formWithCSRF
+  formHelper: FormWithCSRF
 )
 
 @(form: Form[RecycledPlasticWeight])(implicit request: Request[_], messages: Messages)

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/subscriptions/primary_contact_name_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/subscriptions/primary_contact_name_page.scala.html
@@ -15,7 +15,6 @@
  *@
 
 @import uk.gov.hmrc.plasticpackagingtax.returns.forms.subscriptions.Name
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukSummaryList
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.model.Title
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.model.BackButton
@@ -29,7 +28,7 @@
 
 
 @this(
-    formHelper: formWithCSRF,
+    formHelper: FormWithCSRF,
     govukLayout: main_template,
     govukSummaryList: GovukSummaryList,
     govukInput: GovukInput,

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/subscriptions/view_subscription_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/subscriptions/view_subscription_page.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukSummaryList
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.model.Title
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.model.BackButton
@@ -28,7 +27,7 @@
 @import uk.gov.hmrc.plasticpackagingtax.returns.models.subscription.subscriptionDisplay.SubscriptionDisplayResponse
 
 @this(
-    formHelper: formWithCSRF,
+    formHelper: FormWithCSRF,
     govukLayout: main_template,
     govukSummaryList: GovukSummaryList,
     pageTitle: pageTitle,

--- a/build.sbt
+++ b/build.sbt
@@ -14,8 +14,7 @@ lazy val microservice = Project(appName, file("."))
             scalaVersion := "2.12.11",
             libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
             TwirlKeys.templateImports ++= Seq("uk.gov.hmrc.hmrcfrontend.views.html.components._",
-                                              "uk.gov.hmrc.govukfrontend.views.html.components._",
-                                              "uk.gov.hmrc.govukfrontend.views.html.helpers._"
+                                              "uk.gov.hmrc.govukfrontend.views.html.components._"
             ),
             // ***************
             // Use the silencer plugin to suppress warnings

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -23,9 +23,9 @@ play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
 # Primary entry point for all HTTP requests on Play applications
 play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
 
-# Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.bootstrap.AuditModule` or create your own.
+# Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.audit.AuditModule` or create your own.
 # An audit connector must be provided.
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuditModule"
+play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"
 
 # Provides an implementation of MetricsFilter. Use `uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule` or create your own.
 # A metric filter must be provided
@@ -35,7 +35,6 @@ play.modules.enabled += "com.kenshoo.play.metrics.PlayModule"
 
 # Provides an implementation and configures all filters required by a Platform frontend microservice.
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.frontend.FrontendModule"
-play.http.filters = "uk.gov.hmrc.play.bootstrap.frontend.filters.FrontendFilters"
 
 # Default http client
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
@@ -46,7 +45,7 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 # Custom error handler
 play.http.errorHandler = "uk.gov.hmrc.plasticpackagingtax.returns.config.ErrorHandler"
 
-play.filters.headers.contentSecurityPolicy = "default-src 'self' 'unsafe-inline' localhost:9000 localhost:9032 www.google-analytics.com www.googletagmanager.com tagmanager.google.com data:"
+play.filters.csp.CSPFilter = "default-src 'self' 'unsafe-inline' localhost:9000 localhost:9032 www.google-analytics.com www.googletagmanager.com tagmanager.google.com data:"
 
 # Play Modules
 # ~~~~

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,15 +6,14 @@ object AppDependencies {
 
   val compile = Seq(
     ws,
-    "uk.gov.hmrc"                     %% "bootstrap-frontend-play-28" % "5.2.0",
-    "uk.gov.hmrc"                     %% "play-frontend-govuk"        % "0.71.0-play-28",
-    "uk.gov.hmrc"                     %% "play-frontend-hmrc"         % "0.60.0-play-28",
+    "uk.gov.hmrc"                     %% "bootstrap-frontend-play-28" % "5.14.0",
+    "uk.gov.hmrc"                     %% "play-frontend-hmrc"         % "1.11.0-play-28",
     "org.webjars.npm"                 %  "govuk-frontend"             % "3.11.0",
     "org.webjars.npm"                 %  "hmrc-frontend"              % "1.32.0"
   )
 
   val test = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-test-play-28"   % "5.2.0"                 % Test,
+    "uk.gov.hmrc"             %% "bootstrap-test-play-28"   % "5.14.0"                 % Test,
     "org.scalatest"           %% "scalatest"                % "3.2.5"                 % Test,
     "org.jsoup"               %  "jsoup"                    % "1.13.1"                % Test,
     "com.typesafe.play"       %% "play-test"                % current                 % Test,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.4.3")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.5.0")
 
 addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.5.1")
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/audit/AuditorSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/audit/AuditorSpec.scala
@@ -123,27 +123,23 @@ class AuditorSpec extends ConnectorISpec with Injector with ScalaFutures with Ta
     try {
       verify(
         postRequestedFor(urlEqualTo(url))
-          .withRequestBody(equalToJson("""{
-                  "auditSource": "plastic-packaging-tax-returns-frontend",
-                  "auditType": """" + eventType + """",
-                  "eventId": "${json-unit.any-string}",
-                  "tags": {
-                    "clientIP": "-",
-                    "path": "-",
-                    "X-Session-ID": "-",
-                    "Akamai-Reputation": "-",
-                    "X-Request-ID": "-",
-                    "deviceID": "-",
-                    "clientPort": "-"
-                  },
-                  "detail": """ + body + """,
-                  "generatedAt": "${json-unit.any-string}",
-                  "metadata": {
-                    "sendAttemptAt": "${json-unit.any-string}",
-                    "instanceID": "${json-unit.any-string}",
-                    "sequence": "${json-unit.any-number}"
-                  }
-                }""".stripMargin, true, true))
+          .withRequestBody(equalToJson(s"""{
+      |                  "auditSource": "plastic-packaging-tax-returns-frontend",
+      |                  "auditType": "$eventType",
+      |                  "eventId": "$${json-unit.any-string}",
+      |                  "tags": {
+      |                    "clientIP": "-",
+      |                    "path": "-",
+      |                    "X-Session-ID": "-",
+      |                    "Akamai-Reputation": "-",
+      |                    "X-Request-ID": "-",
+      |                    "deviceID": "-",
+      |                    "clientPort": "-"
+      |                  },
+      |                  "detail": $body,
+      |                  "generatedAt": "$${json-unit.any-string}"
+      |                  }
+      |                }""".stripMargin, true, true))
       )
       true
     } catch {


### PR DESCRIPTION
Update versions in AppDependencies.scala and plugins.sbt
- removed play-frontend-govuk lib (pulled in by play-frontend-hmrc)

Code changes due to
- removal of static helpers in play-frontend-govuk
- change in auditing message structure

Fixed following build warnings
```
2021-09-23 07:57:14,694 level=[WARN] logger=[uk.gov.hmrc.play.bootstrap.frontend.filters.FrontendFilters] thread=[pool-1-thread-1] rid user=[] message=[play.http.filters = "uk.gov.hmrc.play.bootstrap.frontend.filters.FrontendFilter" is no longer required and can be removed. Filters are configured using play's default filter system: https://www.playframework.com/documentation/2.7.x/Filters#Default-Filters] 

2021-09-23 07:57:14,693 level=[WARN] logger=[play.filters.headers.SecurityHeadersConfig] thread=[pool-1-thread-1] rid user=[] message=[play.filters.headers.contentSecurityPolicy is deprecated in 2.7.0.  Please use play.filters.csp.CSPFilter instead.] 

2021-09-23 07:57:14,628 level=[WARN] logger=[uk.gov.hmrc.play.bootstrap.config.DeprecatedConfigChecker] thread=[pool-1-thread-1] rid user=[] message=[The key 'play.modules.enabled' is configured with value 'uk.gov.hmrc.play.bootstrap.AuditModule', which is deprecated. Please use 'uk.gov.hmrc.play.audit.AuditModule' instead.] 
```

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed 
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
