### PR TITLE
BAU - auth error handling moved to AuthAction

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/config/ErrorHandler.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/config/ErrorHandler.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.returns.config
 
 import javax.inject.{Inject, Singleton}
 import play.api.i18n.MessagesApi
-import play.api.mvc.{Request, RequestHeader, Result}
+import play.api.mvc.Request
 import play.twirl.api.Html
 import uk.gov.hmrc.plasticpackagingtax.returns.views.html.error_template
 import uk.gov.hmrc.play.bootstrap.frontend.http.FrontendErrorHandler
@@ -31,11 +31,5 @@ class ErrorHandler @Inject() (error_template: error_template, val messagesApi: M
     request: Request[_]
   ): Html =
     error_template(pageTitle, heading, message)
-
-  override def resolveError(rh: RequestHeader, ex: Throwable): Result =
-    ex match {
-
-      case _ => super.resolveError(rh, ex)
-    }
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/config/ErrorHandler.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/config/ErrorHandler.scala
@@ -16,20 +16,16 @@
 
 package uk.gov.hmrc.plasticpackagingtax.returns.config
 
+import javax.inject.{Inject, Singleton}
 import play.api.i18n.MessagesApi
-import play.api.mvc.{Request, RequestHeader, Result, Results}
+import play.api.mvc.{Request, RequestHeader, Result}
 import play.twirl.api.Html
-import uk.gov.hmrc.auth.core.{InsufficientEnrolments, NoActiveSession}
 import uk.gov.hmrc.plasticpackagingtax.returns.views.html.error_template
 import uk.gov.hmrc.play.bootstrap.frontend.http.FrontendErrorHandler
-import uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.{routes => homeRoutes}
-
-import javax.inject.{Inject, Singleton}
 
 @Singleton
-class ErrorHandler @Inject() (error_template: error_template, val messagesApi: MessagesApi)(implicit
-  appConfig: AppConfig
-) extends FrontendErrorHandler {
+class ErrorHandler @Inject() (error_template: error_template, val messagesApi: MessagesApi)
+    extends FrontendErrorHandler {
 
   override def standardErrorTemplate(pageTitle: String, heading: String, message: String)(implicit
     request: Request[_]
@@ -38,10 +34,7 @@ class ErrorHandler @Inject() (error_template: error_template, val messagesApi: M
 
   override def resolveError(rh: RequestHeader, ex: Throwable): Result =
     ex match {
-      case _: NoActiveSession =>
-        Results.Redirect(appConfig.loginUrl, Map("continue" -> Seq(appConfig.loginContinueUrl)))
-      case _: InsufficientEnrolments =>
-        Results.Redirect(homeRoutes.UnauthorisedController.onPageLoad())
+
       case _ => super.resolveError(rh, ex)
     }
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/base/MockAuthAction.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/base/MockAuthAction.scala
@@ -28,6 +28,7 @@ import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
 import uk.gov.hmrc.plasticpackagingtax.returns.base.PptTestData.{newUser, pptEnrolment}
+import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
 import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.{
   AuthActionImpl,
   PptReferenceAllowedList
@@ -40,8 +41,11 @@ trait MockAuthAction extends MockitoSugar with MetricsMocks {
 
   val mockAuthConnector: AuthConnector = mock[AuthConnector]
 
+  private val appConfig = mock[AppConfig]
+
   val mockAuthAction = new AuthActionImpl(mockAuthConnector,
                                           new PptReferenceAllowedList(Seq.empty),
+                                          appConfig,
                                           metricsMock,
                                           stubMessagesControllerComponents()
   )
@@ -158,5 +162,9 @@ trait MockAuthAction extends MockitoSugar with MetricsMocks {
                                   )
       )(any(), any())
     ).thenReturn(Future.failed(new RuntimeException))
+
+  def whenAuthFailsWith(exc: AuthorisationException): Unit =
+    when(mockAuthConnector.authorise(any(), any())(any(), any()))
+      .thenReturn(Future.failed(exc))
 
 }

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/config/ErrorHandlerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/config/ErrorHandlerSpec.scala
@@ -20,24 +20,17 @@ import org.scalatest.OptionValues
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.http.Status.SEE_OTHER
-import play.api.http.Status.INTERNAL_SERVER_ERROR
-import play.api.test.Helpers.{redirectLocation, status, stubMessagesApi}
+import play.api.test.Helpers.stubMessagesApi
 import play.api.test.{DefaultAwaitTimeout, FakeRequest}
-import uk.gov.hmrc.auth.core.{InsufficientEnrolments, NoActiveSession}
-import uk.gov.hmrc.hmrcfrontend.views.Utils.urlEncode
 import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.Injector
 import uk.gov.hmrc.plasticpackagingtax.returns.views.html.error_template
-
-import scala.concurrent.Future
 
 class ErrorHandlerSpec
     extends AnyWordSpec with Injector with DefaultAwaitTimeout with Matchers
     with GuiceOneAppPerSuite with OptionValues {
 
   private val errorPage    = instanceOf[error_template]
-  private val appConfig    = app.injector.instanceOf[AppConfig]
-  private val errorHandler = new ErrorHandler(errorPage, stubMessagesApi())(appConfig)
+  private val errorHandler = new ErrorHandler(errorPage, stubMessagesApi())
 
   "ErrorHandlerSpec" should {
 
@@ -51,34 +44,5 @@ class ErrorHandlerSpec
       result must include("message")
     }
 
-    "handle no active session authorisation exception" in {
-
-      val error  = new NoActiveSession("A user is not logged in") {}
-      val result = Future.successful(errorHandler.resolveError(FakeRequest(), error))
-      val expectedLocation =
-        s"""http://localhost:9949/auth-login-stub/gg-sign-in?continue=${urlEncode(
-          "http://localhost:8505/plastic-packaging-tax/returns/submit-return"
-        )}"""
-
-      status(result) mustBe SEE_OTHER
-      redirectLocation(result) mustBe Some(expectedLocation)
-    }
-
-    "handle insufficient enrolments authorisation exception" in {
-
-      val error  = InsufficientEnrolments("HMRC-PPT-ORG")
-      val result = Future.successful(errorHandler.resolveError(FakeRequest(), error))
-
-      status(result) mustBe SEE_OTHER
-      redirectLocation(result).value must endWith("/unauthorised")
-    }
-
-    "handle all exceptions" in {
-
-      val error  = new RuntimeException("error")
-      val result = Future.successful(errorHandler.resolveError(FakeRequest(), error))
-
-      status(result) mustBe INTERNAL_SERVER_ERROR
-    }
   }
 }

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/config/ErrorHandlerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/config/ErrorHandlerSpec.scala
@@ -20,10 +20,13 @@ import org.scalatest.OptionValues
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.test.Helpers.stubMessagesApi
+import play.api.http.Status.INTERNAL_SERVER_ERROR
+import play.api.test.Helpers.{status, stubMessagesApi}
 import play.api.test.{DefaultAwaitTimeout, FakeRequest}
 import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.Injector
 import uk.gov.hmrc.plasticpackagingtax.returns.views.html.error_template
+
+import scala.concurrent.Future
 
 class ErrorHandlerSpec
     extends AnyWordSpec with Injector with DefaultAwaitTimeout with Matchers
@@ -42,6 +45,14 @@ class ErrorHandlerSpec
       result must include("title")
       result must include("heading")
       result must include("message")
+    }
+
+    "handle all exceptions" in {
+
+      val error  = new RuntimeException("error")
+      val result = Future.successful(errorHandler.resolveError(FakeRequest(), error))
+
+      status(result) mustBe INTERNAL_SERVER_ERROR
     }
 
   }

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/subscriptions/ViewSubscriptionControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/subscriptions/ViewSubscriptionControllerSpec.scala
@@ -143,13 +143,15 @@ class ViewSubscriptionControllerSpec extends ControllerSpec {
       }
     }
 
-    "throw exception" when {
+    "prevent access to page" when {
 
       "user doesn't have correct enrolment" in {
         authorizedUser(PptTestData.newUser("123", None))
-        intercept[InsufficientEnrolments] {
-          await(controller.displayPage()(authRequest(user = PptTestData.newUser("123", None))))
-        }
+
+        val result = controller.displayPage()(authRequest(user = PptTestData.newUser("123", None)))
+
+        status(result) mustBe SEE_OTHER
+        redirectLocation(result) mustBe Some(homeRoutes.UnauthorisedController.onPageLoad().url)
       }
     }
 


### PR DESCRIPTION
### Description of Work carried through

Change the way we handle "authorisation" errors to stop them getting logged as exceptions

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed 
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
