### PR TITLE
PPTP-1066 : Returns preparation info page

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/config/AppConfig.scala
@@ -64,6 +64,7 @@ class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesCo
     s"$pptServiceHost/subscriptions/$pptReference"
 
   lazy val pptRegistrationInfoUrl: String = config.get[String]("urls.pptRegistrationsInfoLink")
+  lazy val pptGuidanceUrl: String         = config.get[String]("urls.pptGuidanceLink")
 
   lazy val feedbackAuthenticatedLink: String = config.get[String]("urls.feedback.authenticatedLink")
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/returns/ReturnsInformationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/returns/ReturnsInformationController.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.returns.controllers.returns
+
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.plasticpackagingtax.returns.views.html.returns.{returns_information_page}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import javax.inject.{Inject, Singleton}
+
+@Singleton
+class ReturnsInformationController @Inject() (
+  mcc: MessagesControllerComponents,
+  returnsInformationPage: returns_information_page
+) extends FrontendController(mcc) with I18nSupport {
+
+  val displayPage: Action[AnyContent] = Action { implicit request =>
+    Ok(returnsInformationPage())
+  }
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/components/bulletList.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/components/bulletList.scala.html
@@ -14,17 +14,14 @@
  * limitations under the License.
  *@
 
-@this(paragraphBody: paragraphBody)
+@this()
 
-@(id: String, title: Option[String] = None, elements: Seq[Html], classes: String = "govuk-body")
+@(elements: Seq[Html], classes: String = "govuk-list govuk-list--bullet", id: Option[String] = None)
 
-<nav title="@id">
-    @title.map(paragraphBody(_, classes))
-    <ul class="govuk-list govuk-list--bullet">
-        @elements.map { element =>
-            <li class="dashed-list-item">
-                @element
-            </li>
-        }
-    </ul>
-</nav>
+<ul class="@classes" @id.map{id => id="@id"}>
+    @elements.map { element =>
+        <li class="dashed-list-item">
+            @element
+        </li>
+    }
+</ul>

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/components/bulletListNavigation.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/components/bulletListNavigation.scala.html
@@ -14,10 +14,19 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.plasticpackagingtax.returns.views.components.Styles.gdsPageHeadingM
+@import uk.gov.hmrc.plasticpackagingtax.returns.views.html.components.paragraphBody
 
-@this()
+@this(paragraphBody: paragraphBody)
 
-@(message: String, classes: String = gdsPageHeadingM, id: Option[String] = Some("section-header"))
+@(id: String, title: Option[String] = None, elements: Seq[Html], classes: String = "govuk-body")
 
-<h2 class="@classes" @id.map{id => id="@id"}>@message</h2>
+<nav title="@id">
+    @title.map(paragraphBody(_, classes))
+    <ul class="govuk-list govuk-list--bullet">
+        @elements.map { element =>
+            <li class="dashed-list-item">
+                @element
+            </li>
+        }
+    </ul>
+</nav>

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/components/pageTitle.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/components/pageTitle.scala.html
@@ -14,11 +14,11 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.plasticpackagingtax.returns.views.components.Styles.gdsPageHeadingXl
+@import uk.gov.hmrc.plasticpackagingtax.returns.views.components.Styles.gdsPageHeadingL
 
 @this()
 
-@(text: String, classes: String = gdsPageHeadingXl)
+@(text: String, classes: String = gdsPageHeadingL)
 
 <h1 id="title" class="@{classes}">@text</h1>
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/components/paragraph.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/components/paragraph.scala.html
@@ -14,10 +14,8 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.plasticpackagingtax.returns.views.components.Styles.gdsPageHeadingM
-
 @this()
 
-@(message: String, classes: String = gdsPageHeadingM, id: Option[String] = Some("section-header"))
+@(content: Html, classes: String = "govuk-body", id: Option[String] = None)
 
-<h2 class="@classes" @id.map{id => id="@id"}>@message</h2>
+<p class="@classes" @id.map{id => id="@id"}>@content</p>

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/confirmation_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/confirmation_page.scala.html
@@ -16,7 +16,7 @@
 
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.model.Title
 @import uk.gov.hmrc.plasticpackagingtax.returns.models.response.FlashKeys
-@import uk.gov.hmrc.plasticpackagingtax.returns.views.html.components.bulletList
+@import uk.gov.hmrc.plasticpackagingtax.returns.views.html.components.bulletListNavigation
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.html.components.paragraphBody
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.html.components.link
 @import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
@@ -28,7 +28,7 @@
     govukLayout: main_template,
     govukPanel : GovukPanel,
     paragraphBody: paragraphBody,
-    bulletList: bulletList,
+    bulletListNavigation: bulletListNavigation,
     link: link,
     appConfig: AppConfig
 )
@@ -66,7 +66,7 @@
 
     @paragraphBody(message = messages("returns.confirmationPage.whatHappensNext.liable.title"))
     <br>
-    @bulletList(
+    @bulletListNavigation(
         id = "in-the-meantime",
         title = Some(messages("returns.confirmationPage.inTheMeantime.title")),
         classes = "govuk-heading-m",

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/returns_information_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/returns_information_page.scala.html
@@ -1,0 +1,73 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.{routes => homeRoutes}
+@import uk.gov.hmrc.plasticpackagingtax.returns.views.html.components.{bulletList, pageTitle, link, paragraph, paragraphBody, sectionHeader}
+@import uk.gov.hmrc.plasticpackagingtax.returns.views.html.main_template
+@import uk.gov.hmrc.plasticpackagingtax.returns.views.model.{BackButton, Title}
+@import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
+
+@this(
+ govukLayout: main_template,
+ pageTitle: pageTitle,
+ sectionHeader: sectionHeader,
+ paragraphBody: paragraphBody,
+ paragraph: paragraph,
+ bulletList: bulletList,
+ link: link,
+ appConfig: AppConfig
+)
+
+@()(implicit request: Request[_], messages: Messages)
+
+@guidanceLink = @{
+ link(
+  id = Some("guidance-link"),
+  newTab = true,
+  text = messages("returns.information.body.4.link.text"),
+  call = Call(
+   method = "GET",
+   url = appConfig.pptGuidanceUrl
+  )
+ )
+}
+
+@govukLayout(
+    title = Title("returns.information.title"),
+    backButton = Some(BackButton(messages("site.back"), homeRoutes.HomeController.displayPage(), messages("site.back.hiddenText")))
+) {
+ @pageTitle(text = messages("returns.information.title"))
+
+ @sectionHeader(message = messages("returns.information.heading1"), id=Some("info-heading"))
+ @paragraphBody(message = messages("returns.information.body.1"), id=Some("info-detail1"))
+ @paragraphBody(message = messages("returns.information.body.2"), id=Some("info-detail2"))
+ @bulletList(
+  id = Some("info-detail-components"),
+  classes = "govuk-list govuk-list--bullet govuk-!-margin-bottom-8",
+  elements = Seq(
+   Html(messages("returns.information.listItem.1")),
+   Html(messages("returns.information.listItem.2")),
+   Html(messages("returns.information.listItem.3")),
+   Html(messages("returns.information.listItem.4")),
+   Html(messages("returns.information.listItem.5"))
+  )
+ )
+
+ @sectionHeader(message = messages("returns.information.heading2"), id=Some("finished-heading"))
+ @paragraphBody(message = messages("returns.information.body.3"), id=Some("finished-detail1"))
+ @paragraph(content = Html(messages("returns.information.body.4.text", guidanceLink)), id=Some("finished-detail2"))
+}
+

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/start_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/start_page.scala.html
@@ -70,9 +70,10 @@ govukButton: GovukButton
         <h2 id="section-1" class="govuk-heading-m">@messages("returns.startPage.informationYouNeed.header")</h2>
         @paragraphBody(message = messages("returns.startPage.informationYouNeed.body"))
 
+        @paragraphBody(message = messages("returns.startPage.informationYouNeed.listItems.header"))
+
         @bulletList(
-            id = "information-you-need-list",
-            title = Some(messages("returns.startPage.informationYouNeed.listItems.header")),
+            id = Some("information-you-need-list"),
             elements = Seq(
                 Html(messages("returns.startPage.informationYouNeed.listItem.1")),
                 Html(messages("returns.startPage.informationYouNeed.listItem.2")),
@@ -97,9 +98,10 @@ govukButton: GovukButton
             @paragraphBody(message = messages("returns.startPage.whatIsLiable.body.1"))
             @paragraphBody(message = messages("returns.startPage.whatIsLiable.body.2"))
 
+            @paragraphBody(message = messages("returns.startPage.whatIsLiable.listItems.header"))
+
             @bulletList(
-                id = "what-is-liable-list",
-                title = Some(messages("returns.startPage.whatIsLiable.listItems.header")),
+                id = Some("what-is-liable-list"),
                 elements = Seq(
                     Html(messages("returns.startPage.whatIsLiable.listItem.1")),
                     Html(messages("returns.startPage.whatIsLiable.listItem.2")),

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -131,6 +131,7 @@ urls {
   }
   govUk = "https://www.gov.uk"
   pptRegistrationsInfoLink = "https://www.gov.uk/government/publications/introduction-of-plastic-packaging-tax/plastic-packaging-tax"
+  pptGuidanceLink = "https://www.gov.uk/government/publications/get-your-business-ready-for-the-plastic-packaging-tax"
 }
 
 accessibility-statement.service-path = "/plastic-packaging-tax"

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -42,6 +42,20 @@ account.homePage.card.registration.body = Review your company’s registration d
 account.homePage.card.registration.link.1 = View your business registration
 account.homePage.card.registration.link.2 = View your primary contact details
 
+returns.information.title = Preparing your Plastic Packaging Tax (PPT) return
+returns.information.heading1 = Information you need to prepare your PPT return
+returns.information.body.1 = You’ll need to enter details of the finished plastic packaging components that you’ve manufactured or imported in this quarter.
+returns.information.body.2 = This includes the total weight of all components that:
+returns.information.listItem.1 = you manufactured, imported or directly exported
+returns.information.listItem.2 = you manufactured or imported but exported through a third party
+returns.information.listItem.3 = you processed and then sent to a third party for further conversion
+returns.information.listItem.4 = contain 30% or more recycled plastic content
+returns.information.listItem.5 = are used for the immediate packaging of human medicine
+returns.information.heading2 = When is a plastic packaging component considered finished?
+returns.information.body.3 = A plastic packaging component is finished when the final manufacturing step is made. You are liable for PPT if you make this final step.
+returns.information.body.4.text = More information, including liability criteria and exemption details, is available in the {0}.
+returns.information.body.4.link.text = PPT guidance (opens in a new tab)
+
 returns.startPage.title = Submit a return
 returns.startPage.title.sectionHeader = Plastic Packaging Tax return
 returns.startPage.informationYouNeed.header = Information you need

--- a/conf/returns.routes
+++ b/conf/returns.routes
@@ -1,5 +1,7 @@
 # microservice specific routes
 
+GET        /return-information   uk.gov.hmrc.plasticpackagingtax.returns.controllers.returns.ReturnsInformationController.displayPage()
+
 GET        /submit-return   uk.gov.hmrc.plasticpackagingtax.returns.controllers.returns.StartController.displayPage()
 
 GET        /manufactured-plastic-packaging-weight       uk.gov.hmrc.plasticpackagingtax.returns.controllers.returns.ManufacturedPlasticWeightController.displayPage()

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/returns/ReturnsInformationControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/returns/ReturnsInformationControllerSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.returns.controllers.returns
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import play.api.http.Status.OK
+import play.api.test.Helpers.{contentAsString, status}
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.ControllerSpec
+import uk.gov.hmrc.plasticpackagingtax.returns.views.html.returns.returns_information_page
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
+
+class ReturnsInformationControllerSpec extends ControllerSpec {
+
+  private val mcc                    = stubMessagesControllerComponents()
+  private val returnsInformationPage = mock[returns_information_page]
+  private val controller             = new ReturnsInformationController(mcc, returnsInformationPage)
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    when(returnsInformationPage.apply()(any(), any())).thenReturn(
+      HtmlFormat.raw("this is the returns information page")
+    )
+  }
+
+  "ReturnsInformationController" should {
+    "display the returns information page" in {
+      val resp = controller.displayPage()(getRequest())
+
+      status(resp) mustBe OK
+      contentAsString(resp) mustBe "this is the returns information page"
+    }
+  }
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/home/SessionTimedOutViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/home/SessionTimedOutViewSpec.scala
@@ -53,9 +53,7 @@ class SessionTimedOutViewSpec extends UnitViewSpec with Matchers {
 
     "display title" in {
 
-      view.getElementsByClass("govuk-heading-xl").first() must containMessage(
-        "sessionTimeout.title"
-      )
+      view.getElementById("title") must containMessage("sessionTimeout.title")
     }
 
     "display saved answers info" in {

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/ConvertedPackagingCreditViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/ConvertedPackagingCreditViewSpec.scala
@@ -70,7 +70,7 @@ class ConvertedPackagingCreditViewSpec extends UnitViewSpec with Matchers {
 
     "display header" in {
 
-      view.getElementsByClass("govuk-caption-xl").text() must include(
+      view.getElementById("section-header").text() must include(
         messages("returns.convertedPackagingCredit.sectionHeader")
       )
     }

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/ExportedPlasticWeightViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/ExportedPlasticWeightViewSpec.scala
@@ -90,7 +90,7 @@ class ExportedPlasticWeightViewSpec extends UnitViewSpec with Matchers {
 
     "display header" in {
 
-      view.getElementsByClass("govuk-caption-xl").text() must include(
+      view.getElementById("section-header").text() must include(
         messages("returns.exportedPlasticWeight.sectionHeader")
       )
     }

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/HumanMedicinesPlasticWeightViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/HumanMedicinesPlasticWeightViewSpec.scala
@@ -91,7 +91,7 @@ class HumanMedicinesPlasticWeightViewSpec extends UnitViewSpec with Matchers {
 
     "display header" in {
 
-      view.getElementsByClass("govuk-caption-xl").text() must include(
+      view.getElementById("section-header").text() must include(
         messages("returns.humanMedicinesPlasticWeight.sectionHeader")
       )
     }

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/ImportedPlasticWeightViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/ImportedPlasticWeightViewSpec.scala
@@ -92,7 +92,7 @@ class ImportedPlasticWeightViewSpec extends UnitViewSpec with Matchers {
 
     "display header" in {
 
-      view.getElementsByClass("govuk-caption-xl").text() must include(
+      view.getElementById("section-header").text() must include(
         messages("returns.importedPlasticWeight.sectionHeader")
       )
     }

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/ManufacturedPlasticWeightViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/ManufacturedPlasticWeightViewSpec.scala
@@ -90,7 +90,7 @@ class ManufacturedPlasticWeightViewSpec extends UnitViewSpec with Matchers {
 
     "display header" in {
 
-      view.getElementsByClass("govuk-caption-xl").text() must include(
+      view.getElementById("section-header").text() must include(
         messages("returns.manufacturedPlasticWeight.sectionHeader")
       )
     }

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/RecycledPlasticWeightViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/RecycledPlasticWeightViewSpec.scala
@@ -87,7 +87,7 @@ class RecycledPlasticWeightViewSpec extends UnitViewSpec with Matchers {
 
     "display header" in {
 
-      view.getElementsByClass("govuk-caption-xl").text() must include(
+      view.getElementById("section-header").text() must include(
         messages("returns.recycledPlasticWeight.sectionHeader")
       )
     }

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/ReturnsInformationPageViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/ReturnsInformationPageViewSpec.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.returns.views.returns
+
+import org.scalatest.matchers.must.Matchers
+import play.api.mvc.{AnyContent, Request}
+import play.api.test.FakeRequest
+import play.twirl.api.Html
+import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
+import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.UnitViewSpec
+import uk.gov.hmrc.plasticpackagingtax.returns.views.html.returns.{returns_information_page}
+import uk.gov.hmrc.plasticpackagingtax.returns.views.tags.ViewTest
+import utils.FakeRequestCSRFSupport.CSRFFakeRequest
+
+@ViewTest
+class ReturnsInformationPageViewSpec extends UnitViewSpec with Matchers {
+
+  override implicit val request: Request[AnyContent] = FakeRequest().withCSRFToken
+
+  private val returnsInformationPage = instanceOf[returns_information_page]
+  private val appConfig              = instanceOf[AppConfig]
+
+  private def createView(): Html = returnsInformationPage()
+
+  "Returns information page" should {
+    "have proper messages for labels" in {
+      messages must haveTranslationFor("returns.information.title")
+      messages must haveTranslationFor("returns.information.heading1")
+      messages must haveTranslationFor("returns.information.body.1")
+      messages must haveTranslationFor("returns.information.body.2")
+      messages must haveTranslationFor("returns.information.listItem.1")
+      messages must haveTranslationFor("returns.information.listItem.2")
+      messages must haveTranslationFor("returns.information.listItem.3")
+      messages must haveTranslationFor("returns.information.listItem.4")
+      messages must haveTranslationFor("returns.information.listItem.5")
+      messages must haveTranslationFor("returns.information.heading2")
+      messages must haveTranslationFor("returns.information.body.3")
+      messages must haveTranslationFor("returns.information.body.4.text")
+      messages must haveTranslationFor("returns.information.body.4.link.text")
+    }
+
+    val view: Html = createView()
+
+    "validate other rendering methods" in {
+      returnsInformationPage.f()(request, messages)
+      returnsInformationPage.render(request, messages)
+    }
+
+    "display title" in {
+      view.select("title").text() must include(messages("returns.information.title"))
+    }
+
+    "display main heading" in {
+      view.select("h1").text() must include(messages("returns.information.title"))
+    }
+
+    "display required information content" in {
+      view.getElementById("info-heading").text() mustBe messages("returns.information.heading1")
+      view.getElementById("info-detail1").text() mustBe messages("returns.information.body.1")
+      view.getElementById("info-detail2").text() mustBe messages("returns.information.body.2")
+      view.getElementById("info-detail-components").text() must include(
+        messages("returns.information.listItem.1")
+      )
+      view.getElementById("info-detail-components").text() must include(
+        messages("returns.information.listItem.2")
+      )
+      view.getElementById("info-detail-components").text() must include(
+        messages("returns.information.listItem.3")
+      )
+      view.getElementById("info-detail-components").text() must include(
+        messages("returns.information.listItem.4")
+      )
+      view.getElementById("info-detail-components").text() must include(
+        messages("returns.information.listItem.5")
+      )
+    }
+
+    "display when finished content" in {
+      view.getElementById("finished-heading").text() mustBe messages("returns.information.heading2")
+      view.getElementById("finished-detail1").text() mustBe messages("returns.information.body.3")
+      view.getElementById("finished-detail2").text() mustBe messages(
+        "returns.information.body.4.text",
+        messages("returns.information.body.4.link.text")
+      )
+    }
+
+    "display guidance link" in {
+      view.getElementById("guidance-link") must haveHref(appConfig.pptGuidanceUrl)
+    }
+  }
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/subscriptions/PrimaryContactNameViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/subscriptions/PrimaryContactNameViewSpec.scala
@@ -85,7 +85,7 @@ class PrimaryContactNameViewSpec extends UnitViewSpec with Matchers {
 
     "display header" in {
 
-      view.getElementsByClass("govuk-caption-xl").text() must include(
+      view.getElementById("section-header").text() must include(
         messages("subscription.primaryContactDetails.title")
       )
     }


### PR DESCRIPTION
A new bulletList component was created for the bullet list on this new page. The original bulletList component was renamed to bulletListNavigation since it was rendering a nav element which used a contained bullet list. The start_page and confirmation_page views were updated to use the new bulletList component since these were not navigational bullet lists.

The pageTitle component was updated to use the "govuk-heading-l" class as per the prototype.

A new paragraph component was added which accepts html content rather than just a String so that links could be wrapped in <p> tags.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed 
 - [x] Required Environment Config has been amended/added - N/A
 - [x] Links to dependencies have been included (BE/FE work) - N/A
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave
