### PR TITLE
BAU - increase view spec code coverage by exercising generated methods

### DIFF
--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/base/unit/UnitViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/base/unit/UnitViewSpec.scala
@@ -28,9 +28,24 @@ import uk.gov.hmrc.plasticpackagingtax.returns.base.PptTestData
 import uk.gov.hmrc.plasticpackagingtax.returns.models.request.AuthenticatedRequest
 import uk.gov.hmrc.plasticpackagingtax.returns.spec.ViewMatchers
 
-class UnitViewSpec
+abstract class UnitViewSpec
     extends AnyWordSpec with MockTaxReturnsConnector with ViewMatchers with Injector
-    with GuiceOneAppPerSuite with ViewAssertions {
+    with GuiceOneAppPerSuite with ViewAssertions with MessagesSupport {
+
+  override def fakeApplication(): Application = {
+    SharedMetricRegistries.clear()
+    new GuiceApplicationBuilder().build()
+  }
+
+  "Exercise generated rendering methods" in {
+    exerciseGeneratedRenderingMethods()
+  }
+
+  def exerciseGeneratedRenderingMethods(): Unit
+
+}
+
+trait MessagesSupport {
 
   import utils.FakeRequestCSRFSupport._
 
@@ -43,16 +58,10 @@ class UnitViewSpec
   protected def messages(key: String, args: Any*)(implicit request: Request[_]): String =
     messages(request)(key, args: _*)
 
-  private val realMessagesApi: MessagesApi = UnitViewSpec.realMessagesApi
-
-  override def fakeApplication(): Application = {
-    SharedMetricRegistries.clear()
-    new GuiceApplicationBuilder().build()
-  }
-
+  private val realMessagesApi: MessagesApi = MessagesSupport.realMessagesApi
 }
 
-object UnitViewSpec extends Injector {
+object MessagesSupport extends Injector {
   val realMessagesApi: MessagesApi = instanceOf[MessagesApi]
 }
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/components/LinkPartialViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/components/LinkPartialViewSpec.scala
@@ -35,6 +35,11 @@ class LinkPartialViewSpec extends UnitViewSpec with Matchers {
   private def createPartial(hiddenText: Option[String] = None): Html =
     linkPartial(text = "visible text", call = Call("GET", "#overview"), textHidden = hiddenText)
 
+  override def exerciseGeneratedRenderingMethods(): Unit = {
+    linkPartial.f("text", None, Call("GET", "#overview"), false, None, "")
+    linkPartial.render("text", None, Call("GET", "#overview"), true, None, "")
+  }
+
   "Link partial" should {
 
     val partial: Html = createPartial()

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/home/HomePageViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/home/HomePageViewSpec.scala
@@ -19,10 +19,10 @@ package uk.gov.hmrc.plasticpackagingtax.returns.views.home
 import org.scalatest.matchers.must.Matchers
 import play.twirl.api.Html
 import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.UnitViewSpec
+import uk.gov.hmrc.plasticpackagingtax.returns.controllers.returns.{routes => returnsRoutes}
 import uk.gov.hmrc.plasticpackagingtax.returns.controllers.subscriptions.{
   routes => subscriptionsRoutes
 }
-import uk.gov.hmrc.plasticpackagingtax.returns.controllers.returns.{routes => returnsRoutes}
 import uk.gov.hmrc.plasticpackagingtax.returns.views.html.home.home_page
 import uk.gov.hmrc.plasticpackagingtax.returns.views.tags.ViewTest
 
@@ -32,6 +32,11 @@ class HomePageViewSpec extends UnitViewSpec with Matchers {
   private val homePage = instanceOf[home_page]
 
   private def createView(): Html = homePage()
+
+  override def exerciseGeneratedRenderingMethods(): Unit = {
+    homePage.f()(request, messages)
+    homePage.render(request, messages)
+  }
 
   "Home Page view" should {
 
@@ -50,15 +55,6 @@ class HomePageViewSpec extends UnitViewSpec with Matchers {
     }
 
     val view: Html = createView()
-
-    "validate other rendering  methods" in {
-      homePage.f()(request, messages).select("title").text() must include(
-        messages("account.homePage.title")
-      )
-      homePage.render(request, messages).select("title").text() must include(
-        messages("account.homePage.title")
-      )
-    }
 
     "contain timeout dialog function" in {
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/home/SessionTimedOutViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/home/SessionTimedOutViewSpec.scala
@@ -34,6 +34,11 @@ class SessionTimedOutViewSpec extends UnitViewSpec with Matchers {
   private val page                   = instanceOf[session_timed_out]
   private def createView(): Document = page()(request, messages)
 
+  override def exerciseGeneratedRenderingMethods(): Unit = {
+    page.f()(request, messages)
+    page.render(request, messages)
+  }
+
   "Session Timeout View" should {
 
     "have proper messages for labels" in {

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/home/UnauthorisedViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/home/UnauthorisedViewSpec.scala
@@ -31,6 +31,11 @@ class UnauthorisedViewSpec extends UnitViewSpec with Matchers {
   private def createView(): Document =
     page()(request, messages)
 
+  override def exerciseGeneratedRenderingMethods(): Unit = {
+    page.f()(request, messages)
+    page.render(request, messages)
+  }
+
   "Unauthorised Page view" should {
 
     "have proper messages for labels" in {

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/home/ViewSubscriptionViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/home/ViewSubscriptionViewSpec.scala
@@ -42,6 +42,11 @@ class ViewSubscriptionViewSpec extends UnitViewSpec with Matchers {
   private val soleTraderView =
     page(createSubscriptionDisplayResponse(soleTraderSubscription))(request, messages)
 
+  override def exerciseGeneratedRenderingMethods(): Unit = {
+    page.f(createSubscriptionDisplayResponse(ukLimitedCompanySubscription))(request, messages)
+    page.render(createSubscriptionDisplayResponse(ukLimitedCompanySubscription), request, messages)
+  }
+
   "ViewSubscriptionView" should {
 
     "have proper messages for labels" in {

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/model/SignOutReasonSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/model/SignOutReasonSpec.scala
@@ -18,9 +18,10 @@ package uk.gov.hmrc.plasticpackagingtax.returns.views.model
 
 import org.scalatest.EitherValues
 import org.scalatest.matchers.must.Matchers
-import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.UnitViewSpec
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.MessagesSupport
 
-class SignOutReasonSpec extends UnitViewSpec with Matchers with EitherValues {
+class SignOutReasonSpec extends AnyWordSpec with MessagesSupport with Matchers with EitherValues {
 
   "Sign out request params binder" should {
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/model/TitleSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/model/TitleSpec.scala
@@ -17,9 +17,10 @@
 package uk.gov.hmrc.plasticpackagingtax.returns.views.model
 
 import org.scalatest.matchers.must.Matchers
-import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.UnitViewSpec
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.MessagesSupport
 
-class TitleSpec extends UnitViewSpec with Matchers {
+class TitleSpec extends AnyWordSpec with MessagesSupport with Matchers {
 
   "Title" should {
     "display title without section header" in {

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/CheckYourReturnViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/CheckYourReturnViewSpec.scala
@@ -19,9 +19,11 @@ package uk.gov.hmrc.plasticpackagingtax.returns.views.returns
 import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
 import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import play.api.mvc.Call
-import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.UnitViewSpec
+import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.{MessagesSupport, UnitViewSpec}
 import uk.gov.hmrc.plasticpackagingtax.returns.controllers.returns.{routes => returnRoutes}
+import uk.gov.hmrc.plasticpackagingtax.returns.spec.ViewMatchers
 import uk.gov.hmrc.plasticpackagingtax.returns.views.html.returns.check_your_return_page
 import uk.gov.hmrc.plasticpackagingtax.returns.views.tags.ViewTest
 
@@ -41,6 +43,11 @@ class CheckYourReturnViewSpec extends UnitViewSpec with Matchers {
 
   private def createView(): Document =
     page(taxReturn)(request, messages)
+
+  override def exerciseGeneratedRenderingMethods(): Unit = {
+    page.f(taxReturn)(request, messages)
+    page.render(taxReturn, request, messages)
+  }
 
   "Check Your Return View" should {
 
@@ -281,7 +288,8 @@ class CheckYourReturnViewSpec extends UnitViewSpec with Matchers {
   }
 }
 
-class CheckYourReturnView(view: Document) extends UnitViewSpec with Matchers {
+class CheckYourReturnView(view: Document)
+    extends AnyWordSpec with MessagesSupport with ViewMatchers with Matchers {
 
   def getTable(tableNo: Int): Element =
     view.getElementsByClass("govuk-table").get(tableNo)

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/ConfirmationViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/ConfirmationViewSpec.scala
@@ -34,6 +34,11 @@ class ConfirmationViewSpec extends UnitViewSpec with Matchers {
   private def createView(flash: Flash = new Flash(Map.empty)): Html =
     page()(request, messages, flash)
 
+  override def exerciseGeneratedRenderingMethods(): Unit = {
+    page.f()(request, messages, new Flash(Map.empty))
+    page.render(request, messages, new Flash(Map.empty))
+  }
+
   "Confirmation Page view" should {
 
     "have proper messages for labels" in {

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/ConvertedPackagingCreditViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/ConvertedPackagingCreditViewSpec.scala
@@ -22,6 +22,7 @@ import play.api.data.Form
 import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.UnitViewSpec
 import uk.gov.hmrc.plasticpackagingtax.returns.controllers.returns.routes
 import uk.gov.hmrc.plasticpackagingtax.returns.forms.ConvertedPackagingCredit
+import uk.gov.hmrc.plasticpackagingtax.returns.forms.ConvertedPackagingCredit.form
 import uk.gov.hmrc.plasticpackagingtax.returns.views.html.returns.converted_packaging_credit_page
 import uk.gov.hmrc.plasticpackagingtax.returns.views.tags.ViewTest
 
@@ -34,6 +35,11 @@ class ConvertedPackagingCreditViewSpec extends UnitViewSpec with Matchers {
     form: Form[ConvertedPackagingCredit] = ConvertedPackagingCredit.form()
   ): Document =
     page(form)(request, messages)
+
+  override def exerciseGeneratedRenderingMethods(): Unit = {
+    page.f(form())(request, messages)
+    page.render(form(), request, messages)
+  }
 
   "Converted Packaging Credit View" should {
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/ExportedPlasticWeightViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/ExportedPlasticWeightViewSpec.scala
@@ -36,6 +36,11 @@ class ExportedPlasticWeightViewSpec extends UnitViewSpec with Matchers {
   ): Document =
     page(form)(request, messages)
 
+  override def exerciseGeneratedRenderingMethods(): Unit = {
+    page.f(form())(request, messages)
+    page.render(form(), request, messages)
+  }
+
   "Exported Plastic Weight View" should {
 
     "have proper messages for labels" in {
@@ -56,15 +61,6 @@ class ExportedPlasticWeightViewSpec extends UnitViewSpec with Matchers {
     }
 
     val view = createView()
-
-    "validate other rendering  methods" in {
-      page.f(form())(request, messages).select("title").text() must include(
-        messages("returns.exportedPlasticWeight.title")
-      )
-      page.render(form(), request, messages).select("title").text() must include(
-        messages("returns.exportedPlasticWeight.title")
-      )
-    }
 
     "contain timeout dialog function" in {
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/HumanMedicinesPlasticWeightViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/HumanMedicinesPlasticWeightViewSpec.scala
@@ -36,6 +36,11 @@ class HumanMedicinesPlasticWeightViewSpec extends UnitViewSpec with Matchers {
   ): Document =
     page(form)(request, messages)
 
+  override def exerciseGeneratedRenderingMethods(): Unit = {
+    page.f(form())(request, messages)
+    page.render(form(), request, messages)
+  }
+
   "Human Medicines Plastic Weight View" should {
 
     "have proper messages for labels" in {
@@ -55,15 +60,6 @@ class HumanMedicinesPlasticWeightViewSpec extends UnitViewSpec with Matchers {
     }
 
     val view = createView()
-
-    "validate other rendering  methods" in {
-      page.f(form())(request, messages).select("title").text() must include(
-        messages("returns.humanMedicinesPlasticWeight.meta.title")
-      )
-      page.render(form(), request, messages).select("title").text() must include(
-        messages("returns.humanMedicinesPlasticWeight.meta.title")
-      )
-    }
 
     "contain timeout dialog function" in {
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/ImportedPlasticWeightViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/ImportedPlasticWeightViewSpec.scala
@@ -36,6 +36,11 @@ class ImportedPlasticWeightViewSpec extends UnitViewSpec with Matchers {
   ): Document =
     page(form)(request, messages)
 
+  override def exerciseGeneratedRenderingMethods(): Unit = {
+    page.f(form())(request, messages)
+    page.render(form(), request, messages)
+  }
+
   "Imported Plastic Weight View" should {
 
     "have proper messages for labels" in {
@@ -58,15 +63,6 @@ class ImportedPlasticWeightViewSpec extends UnitViewSpec with Matchers {
     }
 
     val view = createView()
-
-    "validate other rendering  methods" in {
-      page.f(form())(request, messages).select("title").text() must include(
-        messages("returns.importedPlasticWeight.meta.title")
-      )
-      page.render(form(), request, messages).select("title").text() must include(
-        messages("returns.importedPlasticWeight.meta.title")
-      )
-    }
 
     "contain timeout dialog function" in {
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/ManufacturedPlasticWeightViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/ManufacturedPlasticWeightViewSpec.scala
@@ -36,6 +36,11 @@ class ManufacturedPlasticWeightViewSpec extends UnitViewSpec with Matchers {
   ): Document =
     page(form)(request, messages)
 
+  override def exerciseGeneratedRenderingMethods(): Unit = {
+    page.f(form())(request, messages)
+    page.render(form(), request, messages)
+  }
+
   "Manufactured Plastic Weight View" should {
 
     "have proper messages for labels" in {
@@ -56,15 +61,6 @@ class ManufacturedPlasticWeightViewSpec extends UnitViewSpec with Matchers {
     }
 
     val view = createView()
-
-    "validate other rendering  methods" in {
-      page.f(form())(request, messages).select("title").text() must include(
-        messages("returns.manufacturedPlasticWeight.meta.title")
-      )
-      page.render(form(), request, messages).select("title").text() must include(
-        messages("returns.manufacturedPlasticWeight.meta.title")
-      )
-    }
 
     "contain timeout dialog function" in {
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/RecycledPlasticWeightViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/RecycledPlasticWeightViewSpec.scala
@@ -36,6 +36,11 @@ class RecycledPlasticWeightViewSpec extends UnitViewSpec with Matchers {
   ): Document =
     page(form)(request, messages)
 
+  override def exerciseGeneratedRenderingMethods(): Unit = {
+    page.f(form())(request, messages)
+    page.render(form(), request, messages)
+  }
+
   "Recycled Plastic Weight View" should {
 
     "have proper messages for labels" in {
@@ -53,15 +58,6 @@ class RecycledPlasticWeightViewSpec extends UnitViewSpec with Matchers {
     }
 
     val view = createView()
-
-    "validate other rendering  methods" in {
-      page.f(form())(request, messages).select("title").text() must include(
-        messages("returns.recycledPlasticWeight.meta.title")
-      )
-      page.render(form(), request, messages).select("title").text() must include(
-        messages("returns.recycledPlasticWeight.meta.title")
-      )
-    }
 
     "contain timeout dialog function" in {
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/ReturnsInformationPageViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/ReturnsInformationPageViewSpec.scala
@@ -36,6 +36,11 @@ class ReturnsInformationPageViewSpec extends UnitViewSpec with Matchers {
 
   private def createView(): Html = returnsInformationPage()
 
+  override def exerciseGeneratedRenderingMethods(): Unit = {
+    returnsInformationPage.f()(request, messages)
+    returnsInformationPage.render(request, messages)
+  }
+
   "Returns information page" should {
     "have proper messages for labels" in {
       messages must haveTranslationFor("returns.information.title")
@@ -54,11 +59,6 @@ class ReturnsInformationPageViewSpec extends UnitViewSpec with Matchers {
     }
 
     val view: Html = createView()
-
-    "validate other rendering methods" in {
-      returnsInformationPage.f()(request, messages)
-      returnsInformationPage.render(request, messages)
-    }
 
     "display title" in {
       view.select("title").text() must include(messages("returns.information.title"))

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/StartPageViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/StartPageViewSpec.scala
@@ -35,6 +35,11 @@ class StartPageViewSpec extends UnitViewSpec with Matchers {
 
   private def createView(): Html = startPage()
 
+  override def exerciseGeneratedRenderingMethods(): Unit = {
+    startPage.f()(request, messages)
+    startPage.render(request, messages)
+  }
+
   "Start Page view" should {
 
     "have proper messages for labels" in {
@@ -61,15 +66,6 @@ class StartPageViewSpec extends UnitViewSpec with Matchers {
     }
 
     val view: Html = createView()
-
-    "validate other rendering  methods" in {
-      startPage.f()(request, messages).select("title").text() must include(
-        messages("returns.startPage.title")
-      )
-      startPage.render(request, messages).select("title").text() must include(
-        messages("returns.startPage.title")
-      )
-    }
 
     "display title" in {
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/subscriptions/PrimaryContactNameViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/subscriptions/PrimaryContactNameViewSpec.scala
@@ -36,6 +36,11 @@ class PrimaryContactNameViewSpec extends UnitViewSpec with Matchers {
   private def createView(form: Form[Name] = Name.form()): Document =
     page(form)(request, messages)
 
+  override def exerciseGeneratedRenderingMethods(): Unit = {
+    page.f(form())(request, messages)
+    page.render(form(), request, messages)
+  }
+
   "Primary Contact Name View" should {
 
     "have proper messages for labels" in {
@@ -49,15 +54,6 @@ class PrimaryContactNameViewSpec extends UnitViewSpec with Matchers {
     }
 
     val view = createView()
-
-    "validate other rendering  methods" in {
-      page.f(form())(request, messages).select("title").text() must include(
-        messages("subscription.primaryContactDetails.name.title")
-      )
-      page.render(form(), request, messages).select("title").text() must include(
-        messages("subscription.primaryContactDetails.name.title")
-      )
-    }
 
     "contain timeout dialog function" in {
 


### PR DESCRIPTION
### Description of Work carried through

Made UnitViewSpec abstract to encourage ViewSpecs to exercise generated render methods

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed 
