### PR TITLE
PPTP-1067 - fix for sub-headings on PPT information page

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/components/subHeading.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/components/subHeading.scala.html
@@ -1,0 +1,23 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.plasticpackagingtax.returns.views.components.Styles.gdsPageHeadingM
+
+@this()
+
+@(message: String, classes: String = gdsPageHeadingM, id: Option[String] = None)
+
+<h2 class="@{classes}" @id.map{id => id="@id"}>@message</h2>

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/returns_information_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/returns_information_page.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.{routes => homeRoutes}
-@import uk.gov.hmrc.plasticpackagingtax.returns.views.html.components.{bulletList, pageTitle, link, paragraph, paragraphBody, sectionHeader}
+@import uk.gov.hmrc.plasticpackagingtax.returns.views.html.components.{bulletList, pageTitle, link, paragraph, paragraphBody, subHeading}
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.html.main_template
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.model.{BackButton, Title}
 @import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
@@ -23,7 +23,7 @@
 @this(
  govukLayout: main_template,
  pageTitle: pageTitle,
- sectionHeader: sectionHeader,
+ subHeading: subHeading,
  paragraphBody: paragraphBody,
  paragraph: paragraph,
  bulletList: bulletList,
@@ -51,7 +51,7 @@
 ) {
  @pageTitle(text = messages("returns.information.title"))
 
- @sectionHeader(message = messages("returns.information.heading1"), id=Some("info-heading"))
+ @subHeading(message = messages("returns.information.heading1"), id=Some("info-heading"))
  @paragraphBody(message = messages("returns.information.body.1"), id=Some("info-detail1"))
  @paragraphBody(message = messages("returns.information.body.2"), id=Some("info-detail2"))
  @bulletList(
@@ -66,7 +66,7 @@
   )
  )
 
- @sectionHeader(message = messages("returns.information.heading2"), id=Some("finished-heading"))
+ @subHeading(message = messages("returns.information.heading2"), id=Some("finished-heading"))
  @paragraphBody(message = messages("returns.information.body.3"), id=Some("finished-detail1"))
  @paragraph(content = Html(messages("returns.information.body.4.text", guidanceLink)), id=Some("finished-detail2"))
 }


### PR DESCRIPTION
Create new "subHeading" component for <h2> elements

sectionHeading element had been previously changed to render "captions" above H1

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed 
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave

![image](https://user-images.githubusercontent.com/46934286/137172092-85a3bdac-b397-4568-a849-20f00eee21a0.png)
