### PR TITLE
BAU : Ensure TaxReturn changes are backwards-compat

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/audit/CreateTaxReturnEvent.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/audit/CreateTaxReturnEvent.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.plasticpackagingtax.returns.models.obligations.Obligation
 
 case class CreateTaxReturnEvent(
   id: String,
-  obligation: Obligation,
+  obligation: Option[Obligation] = None,
   manufacturedPlasticWeight: Option[ManufacturedPlasticWeight] = None,
   importedPlasticWeight: Option[ImportedPlasticWeight] = None,
   humanMedicinesPlasticWeight: Option[HumanMedicinesPlasticWeight] = None,

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/models/domain/TaxReturn.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/models/domain/TaxReturn.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.plasticpackagingtax.returns.utils.TaxLiabilityFactory
 
 case class TaxReturn(
   id: String,
-  obligation: Obligation,
+  obligation: Option[Obligation] = None,
   manufacturedPlasticWeight: Option[ManufacturedPlasticWeight] = None,
   importedPlasticWeight: Option[ImportedPlasticWeight] = None,
   humanMedicinesPlasticWeight: Option[HumanMedicinesPlasticWeight] = None,

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/models/request/JourneyAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/models/request/JourneyAction.scala
@@ -69,7 +69,7 @@ class JourneyAction @Inject() (returnsConnector: TaxReturnsConnector, auditor: A
                                               dueDate = LocalDate.parse("2022-06-30"),
                                               periodKey = "22AP"
             )
-            returnsConnector.create(TaxReturn(id = id, obligation = oldestObligation))
+            returnsConnector.create(TaxReturn(id = id, obligation = Some(oldestObligation)))
           }
       case Left(error) => Future.successful(Left(error))
     }

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/builders/TaxReturnBuilder.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/builders/TaxReturnBuilder.scala
@@ -38,7 +38,7 @@ trait TaxReturnBuilder {
     modifiers.foldLeft(modelWithDefaults)((current, modifier) => modifier(current))
 
   private def modelWithDefaults: TaxReturn =
-    TaxReturn(id = "id", obligation = defaultObligation)
+    TaxReturn(id = "id", obligation = Some(defaultObligation))
 
   val defaultObligation = Obligation(fromDate = LocalDate.parse("2022-04-01"),
                                      toDate = LocalDate.parse("2022-06-30"),


### PR DESCRIPTION
This is necessary since successful registration results in the creation of a TaxReturn. Thus, we need to remain compatible with these existing TaxReturns which exist in the production Returns Mongo.
