### PR TITLE
PPTP-1762 - Agents with delegated access can access Plastics Returns

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
@@ -128,14 +128,12 @@ class AuthActionImpl @Inject() (
       Future.successful(Results.Redirect(homeRoutes.UnauthorisedController.onPageLoad()))
     }
 
-  private def getPptEnrolmentId(enrolments: Enrolments, identifier: String): Option[String] = {
-    val maybeEnrolmentIdentifier = getPptEnrolmentIdentifier(enrolments, identifier)
-    maybeEnrolmentIdentifier match {
+  private def getPptEnrolmentId(enrolments: Enrolments, identifier: String): Option[String] =
+    getPptEnrolmentIdentifier(enrolments, identifier) match {
       case Some(enrolmentIdentifier) =>
         Option(enrolmentIdentifier).filter(_.value.trim.nonEmpty).map(_.value)
       case None => Option.empty
     }
-  }
 
   private def getPptEnrolmentIdentifier(
     enrolmentsList: Enrolments,

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
@@ -49,8 +49,7 @@ class AuthActionImpl @Inject() (
   private val logger                                       = Logger(this.getClass)
   private val authTimer                                    = metrics.defaultRegistry.timer("ppt.returns.upstream.auth.timer")
 
-  private def authPredicate =
-    AffinityGroup.Organisation and (Enrolment("HMRC-PPT-ORG").withDelegatedAuthRule("ppt-auth"))
+  private def authPredicate = Enrolment("HMRC-PPT-ORG").withDelegatedAuthRule("ppt-auth")
 
   private val authData =
     credentials and name and email and externalId and internalId and affinityGroup and allEnrolments and

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/base/MockAuthAction.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/base/MockAuthAction.scala
@@ -75,10 +75,14 @@ trait MockAuthAction extends MockitoSugar with MetricsMocks {
   val nrsLoginTimes               = LoginTimes(currentLoginTime, Some(previousLoginTime))
 
   // format: off
-  def authorizedUser(user: SignedInUser = exampleUser): Unit =
+  def authorizedUser(user: SignedInUser = exampleUser): Unit = {
+    val delegatedAuthRule = "ppt-auth" // Required for Agent access control; tells auth how the agent access decision is made
+    val enrolmentPredicated =
+      AffinityGroup.Organisation and Enrolment("HMRC-PPT-ORG").withDelegatedAuthRule(delegatedAuthRule)
+
     when(
       mockAuthConnector.authorise(
-        any(),
+        ArgumentMatchers.eq(enrolmentPredicated),
         ArgumentMatchers.eq(
           credentials and name and email and externalId and internalId and affinityGroup and allEnrolments
             and agentCode and confidenceLevel and nino and saUtr and dateOfBirth and agentInformation and groupIdentifier and
@@ -150,6 +154,7 @@ trait MockAuthAction extends MockitoSugar with MetricsMocks {
         )
       )
     )
+  }
   // format: on
 
   def unAuthorizedUser(): Unit =

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/base/MockAuthAction.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/base/MockAuthAction.scala
@@ -77,12 +77,11 @@ trait MockAuthAction extends MockitoSugar with MetricsMocks {
   // format: off
   def authorizedUser(user: SignedInUser = exampleUser): Unit = {
     val delegatedAuthRule = "ppt-auth" // Required for Agent access control; tells auth how the agent access decision is made
-    val enrolmentPredicated =
-      AffinityGroup.Organisation and Enrolment("HMRC-PPT-ORG").withDelegatedAuthRule(delegatedAuthRule)
+    val enrolmentPredicate = Enrolment("HMRC-PPT-ORG").withDelegatedAuthRule(delegatedAuthRule)
 
     when(
       mockAuthConnector.authorise(
-        ArgumentMatchers.eq(enrolmentPredicated),
+        ArgumentMatchers.eq(enrolmentPredicate),
         ArgumentMatchers.eq(
           credentials and name and email and externalId and internalId and affinityGroup and allEnrolments
             and agentCode and confidenceLevel and nino and saUtr and dateOfBirth and agentInformation and groupIdentifier and

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthActionSpec.scala
@@ -103,6 +103,7 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
 
       val result = createAuthAction().invokeBlock(authRequest(Headers(), user), okResponseGenerator)
 
+      status(result) mustBe SEE_OTHER
       redirectLocation(result) mustBe Some(homeRoutes.UnauthorisedController.onPageLoad().url)
     }
 
@@ -183,6 +184,7 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
                                        okResponseGenerator
         )
 
+      status(result) mustBe SEE_OTHER
       redirectLocation(result) mustBe Some(homeRoutes.UnauthorisedController.onPageLoad().url)
     }
   }


### PR DESCRIPTION
### Description of Work carried through

Agents who have been delegated access can access PPT returns.

- AuthAction uses the authorisation Enrolment predicate to explicitly request the PPT enrol from auth.

- The `auth` service will only evaluate an agent delegation for an Enrolment if it is explicitly mentioned in the authorisation predicate (See [auth AgentDelegationPredicate](/hmrc/auth/blob/main/app/auth/authorise/predicate/AgentDelegationPredicate.scala))
The enrolments currently fetched using retrieve allEnrolments have non be evaluated for agent access.
 
- The Enrolment predicate is marked with the `ppt-auth` delegated auth rule.
We believe that `auth` passes this parameter to `agent-access-control` which looks for an agent delegation.


The existing behaviour of redirecting non enrolled users to registration front end is preserved.
This works because the authorised predicate throws the same `InsufficientEnrolments` exception is our existing wrapped enrolment filtering code.

What happens when an agent is redirected to registration is let as en exercise for the reader.
Mileage may vary but this is probably safe if registration is protected with an Organisation AffinityGroup check.
An agent specific error page in registration would probably close this down nicely.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed 
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
