### PR TITLE
PPTP-1755 - Removing plastic-packaging-tax from url

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ sm -s
 ```
 
 * Visit http://localhost:9949/auth-login-stub/gg-sign-in
-* Enter the redirect url: http://localhost:8505/plastic-packaging-tax/submit-return-for-plastic-packaging-tax/submit-return and press **Submit**.
+* Enter the redirect url: http://localhost:8505/submit-return-for-plastic-packaging-tax/submit-return and press **Submit**.
 
 
 ### Precheck

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -130,7 +130,7 @@ assets {
 urls {
   exitSurvey = "http://localhost:9514/feedback/plastic-packaging-tax-registration"
   login = "http://localhost:9949/auth-login-stub/gg-sign-in"
-  loginContinue = "http://localhost:8505/plastic-packaging-tax/submit-return-for-plastic-packaging-tax/submit-return"
+  loginContinue = "http://localhost:8505/submit-return-for-plastic-packaging-tax/submit-return"
   feedback = {
     authenticatedLink = "http://localhost:9250/contact/beta-feedback"
     unauthenticatedLink = "http://localhost:9250/contact/beta-feedback-unauthenticated"

--- a/tampermonkey/PPT_Returns_Auth_AutoComplete.js
+++ b/tampermonkey/PPT_Returns_Auth_AutoComplete.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name     Plastic Packaging Tax Returns(PPT) Authorisation
 // @namespace  http://tampermonkey.net/
-// @version   3.3
+// @version   3.4
 // @description Auth Wizard autocomplete script for PPT
 // @author    pmonteiro
 // @match     http*://*/auth-login-stub/gg-sign-in?continue=*plastic-packaging-tax%2Fsubmit-return-for-plastic-packaging-tax*
@@ -12,7 +12,7 @@
 (function() {
     'use strict';
 
-    document.getElementsByName("redirectionUrl")[0].value = getBaseUrl() + "/plastic-packaging-tax/submit-return-for-plastic-packaging-tax/submit-return";
+    document.getElementsByName("redirectionUrl")[0].value = getBaseUrl() + "/submit-return-for-plastic-packaging-tax/submit-return";
 
     document.getElementById("affinityGroupSelect").selectedIndex = 1;
 

--- a/tampermonkey/PPT_Returns_AutoComplete.js
+++ b/tampermonkey/PPT_Returns_AutoComplete.js
@@ -1,10 +1,10 @@
 // ==UserScript==
 // @name         PPT Returns AutoComplete
 // @namespace    http://tampermonkey.net/
-// @version      5.1
+// @version      5.2
 // @description
 // @author       pmonteiro
-// @match        http*://*/plastic-packaging-tax/submit-return-for-plastic-packaging-tax*
+// @match        http*://*/submit-return-for-plastic-packaging-tax*
 // @grant GM_setValue
 // @grant GM_getValue
 // @updateURL    https://raw.githubusercontent.com/hmrc/plastic-packaging-tax-returns-frontend/master/tampermonkey/PPT_Returns_AutoComplete.js
@@ -55,14 +55,14 @@ const currentPageIs = (path) => {
 
 /*########################     PPT REGISTRATION PAGES     ########################## */
 const startPage = () => {
-    if (currentPageIs('/plastic-packaging-tax/submit-return-for-plastic-packaging-tax/submit-return')) {
+    if (currentPageIs('/submit-return-for-plastic-packaging-tax/submit-return')) {
 
         document.getElementsByClassName('govuk-button')[0].click()
     }
 }
 
 const manufacturedWeightPage = () => {
-    if (currentPageIs('/plastic-packaging-tax/submit-return-for-plastic-packaging-tax/manufactured-plastic-packaging-weight')) {
+    if (currentPageIs('/submit-return-for-plastic-packaging-tax/manufactured-plastic-packaging-weight')) {
 
         document.getElementById('totalKg').value = '10'
         document.getElementsByClassName('govuk-button')[0].click()
@@ -70,7 +70,7 @@ const manufacturedWeightPage = () => {
 }
 
 const importedWeightPage = () => {
-    if (currentPageIs('/plastic-packaging-tax/submit-return-for-plastic-packaging-tax/imported-plastic-packaging-weight')) {
+    if (currentPageIs('/submit-return-for-plastic-packaging-tax/imported-plastic-packaging-weight')) {
 
         document.getElementById('totalKg').value = '20'
         document.getElementsByClassName('govuk-button')[0].click()
@@ -78,7 +78,7 @@ const importedWeightPage = () => {
 }
 
 const humanMedicinesWeightPage = () => {
-    if (currentPageIs('/plastic-packaging-tax/submit-return-for-plastic-packaging-tax/human-medicines-packaging-weight')) {
+    if (currentPageIs('/submit-return-for-plastic-packaging-tax/human-medicines-packaging-weight')) {
 
         document.getElementById('totalKg').value = '1'
         document.getElementsByClassName('govuk-button')[0].click()
@@ -86,7 +86,7 @@ const humanMedicinesWeightPage = () => {
 }
 
 const exportedPackagingWeightPage = () => {
-    if (currentPageIs('/plastic-packaging-tax/submit-return-for-plastic-packaging-tax/exported-plastic-packaging-weight')) {
+    if (currentPageIs('/submit-return-for-plastic-packaging-tax/exported-plastic-packaging-weight')) {
 
         document.getElementById('totalKg').value = '2'
         document.getElementsByClassName('govuk-button')[0].click()
@@ -94,7 +94,7 @@ const exportedPackagingWeightPage = () => {
 }
 
 const convertedPackagingCreditPage = () => {
-    if (currentPageIs('/plastic-packaging-tax/submit-return-for-plastic-packaging-tax/converted-plastic-packaging-credit')) {
+    if (currentPageIs('/submit-return-for-plastic-packaging-tax/converted-plastic-packaging-credit')) {
 
         document.getElementById('totalInPence').value = '200.34'
         document.getElementsByClassName('govuk-button')[0].click()
@@ -102,7 +102,7 @@ const convertedPackagingCreditPage = () => {
 }
 
 const recycledWeightPage = () => {
-    if (currentPageIs('/plastic-packaging-tax/submit-return-for-plastic-packaging-tax/recycled-plastic-packaging')) {
+    if (currentPageIs('/submit-return-for-plastic-packaging-tax/recycled-plastic-packaging')) {
 
         document.getElementById('totalKg').value = '10'
         document.getElementsByClassName('govuk-button')[0].click()
@@ -110,14 +110,14 @@ const recycledWeightPage = () => {
 }
 
 const reviewReturn = () => {
-     if (currentPageIs('/plastic-packaging-tax/submit-return-for-plastic-packaging-tax/check-your-return')) {
+     if (currentPageIs('/submit-return-for-plastic-packaging-tax/check-your-return')) {
 
          document.getElementsByClassName('govuk-button')[0].click()
      }
 }
 
 const confirmationPage = () => {
-     if (currentPageIs('/plastic-packaging-tax/submit-return-for-plastic-packaging-tax/return-complete')) {
+     if (currentPageIs('/submit-return-for-plastic-packaging-tax/return-complete')) {
 
          document.getElementsByClassName('govuk-link')[5].click()
      }


### PR DESCRIPTION
### Description of Work carried through

Updating the url to remove the service name prefix `plastic-packaging-tax` from the url.

https://github.com/hmrc/app-config-base/pull/6870

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed 
 - [x] Required Environment Config has been amended/added
 - [x] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
