### PR TITLE
Correct path for returns backend end points

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/config/AppConfig.scala
@@ -56,7 +56,7 @@ class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesCo
   lazy val pptServiceHost: String =
     servicesConfig.baseUrl("plastic-packaging-tax-returns")
 
-  lazy val pptReturnsUrl: String = s"$pptServiceHost/submit-return-for-plastic-packaging-tax"
+  lazy val pptReturnsUrl: String = s"$pptServiceHost/returns"
 
   def pptReturnUrl(id: String): String = s"$pptReturnsUrl/$id"
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/connectors/TaxReturnsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/connectors/TaxReturnsConnectorSpec.scala
@@ -96,7 +96,7 @@ class TaxReturnsConnectorSpec
 
   private def givenPostToReturnsEndpointReturns(status: Int, body: String = "") =
     stubFor(
-      post("/submit-return-for-plastic-packaging-tax")
+      post("/returns")
         .willReturn(
           aResponse()
             .withStatus(status)
@@ -149,7 +149,7 @@ class TaxReturnsConnectorSpec
 
   private def givenGetReturnsEndpointReturns(status: Int, body: String = "") =
     stubFor(
-      get("/submit-return-for-plastic-packaging-tax/123")
+      get("/returns/123")
         .willReturn(
           aResponse()
             .withStatus(status)
@@ -212,7 +212,7 @@ class TaxReturnsConnectorSpec
 
   private def givenPutToReReturnsEndpointReturns(status: Int, id: String, body: String = "") =
     stubFor(
-      put(s"/submit-return-for-plastic-packaging-tax/$id")
+      put(s"/returns/$id")
         .willReturn(
           aResponse()
             .withStatus(status)


### PR DESCRIPTION
### Description of Work carried through

Probably restores returns based pages.
Frontend url change was applied to a back end end point path.


#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed 
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
