### PR TITLE
Returns loginContinue urls needs to be prefixed to work locally

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -130,7 +130,7 @@ assets {
 urls {
   exitSurvey = "http://localhost:9514/feedback/plastic-packaging-tax-registration"
   login = "http://localhost:9949/auth-login-stub/gg-sign-in"
-  loginContinue = "http://localhost:8505/submit-return-for-plastic-packaging-tax/submit-return"
+  loginContinue = "http://localhost:8505/plastic-packaging-tax/submit-return-for-plastic-packaging-tax/submit-return"
   feedback = {
     authenticatedLink = "http://localhost:9250/contact/beta-feedback"
     unauthenticatedLink = "http://localhost:9250/contact/beta-feedback-unauthenticated"


### PR DESCRIPTION
 (and possibly in the real environments as well)

Looks like services cannot assign themselves root paths on the platform.
This fixes local sign in journey redirect url.

### Description of Work carried through

Brief description of what/why/how.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed 
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
