### PR TITLE
Use auth enrolment predicate

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
@@ -49,6 +49,8 @@ class AuthActionImpl @Inject() (
   private val logger                                       = Logger(this.getClass)
   private val authTimer                                    = metrics.defaultRegistry.timer("ppt.returns.upstream.auth.timer")
 
+  private def authPredicate = Enrolment("HMRC-PPT-ORG").withDelegatedAuthRule("ppt-auth")
+
   private val authData =
     credentials and name and email and externalId and internalId and affinityGroup and allEnrolments and
       agentCode and confidenceLevel and nino and saUtr and dateOfBirth and agentInformation and groupIdentifier and
@@ -61,12 +63,13 @@ class AuthActionImpl @Inject() (
     implicit val hc: HeaderCarrier =
       HeaderCarrierConverter.fromRequestAndSession(request, request.session)
     val authorisation = authTimer.time()
-    authorised()
+    authorised(authPredicate)
       .retrieve(authData) {
         case credentials ~ name ~ email ~ externalId ~ internalId ~ affinityGroup ~ allEnrolments ~ agentCode ~
             confidenceLevel ~ authNino ~ saUtr ~ dateOfBirth ~ agentInformation ~ groupIdentifier ~
             credentialRole ~ mdtpInformation ~ itmpName ~ itmpDateOfBirth ~ itmpAddress ~ credentialStrength ~ loginTimes =>
           authorisation.stop()
+
           val identityData = IdentityData(internalId,
                                           externalId,
                                           agentCode,
@@ -94,11 +97,16 @@ class AuthActionImpl @Inject() (
               throw InsufficientEnrolments(
                 s"key: $pptEnrolmentKey and identifier: $pptEnrolmentIdentifierName is not found"
               )
-            case Some(id) => executeRequest(request, block, identityData, id, allEnrolments)
+            case Some(pptEnrolmentIdentifier) =>
+              executeRequest(request, block, identityData, pptEnrolmentIdentifier, allEnrolments)
           }
+
       } recover {
       case _: NoActiveSession =>
         Results.Redirect(appConfig.loginUrl, Map("continue" -> Seq(appConfig.loginContinueUrl)))
+      case _: InsufficientEnrolments =>
+        // Authenticated users who lack PPT enrolments are redirected to registration frontend
+        Results.Redirect(homeRoutes.UnauthorisedController.onPageLoad())
       case _: AuthorisationException =>
         Results.Redirect(homeRoutes.UnauthorisedController.onPageLoad())
     }
@@ -108,24 +116,25 @@ class AuthActionImpl @Inject() (
     request: Request[A],
     block: AuthenticatedRequest[A] => Future[Result],
     identityData: IdentityData,
-    id: String,
+    pptEnrolmentIdentifier: String,
     allEnrolments: Enrolments
   ) =
-    if (pptReferenceAllowedList.isAllowed(id)) {
+    if (pptReferenceAllowedList.isAllowed(pptEnrolmentIdentifier)) {
       val pptLoggedInUser = SignedInUser(allEnrolments, identityData)
-      block(new AuthenticatedRequest(request, pptLoggedInUser, Some(id)))
+      block(new AuthenticatedRequest(request, pptLoggedInUser, Some(pptEnrolmentIdentifier)))
     } else {
       logger.warn("User id is not allowed, access denied")
       Future.successful(Results.Redirect(homeRoutes.UnauthorisedController.onPageLoad()))
     }
 
   private def getPptEnrolmentId(enrolments: Enrolments, identifier: String): Option[String] =
-    getPptEnrolment(enrolments, identifier) match {
-      case Some(enrolmentId) => Option(enrolmentId).filter(_.value.trim.nonEmpty).map(_.value)
-      case None              => Option.empty
+    getPptEnrolmentIdentifier(enrolments, identifier) match {
+      case Some(enrolmentIdentifier) =>
+        Option(enrolmentIdentifier).filter(_.value.trim.nonEmpty).map(_.value)
+      case None => Option.empty
     }
 
-  private def getPptEnrolment(
+  private def getPptEnrolmentIdentifier(
     enrolmentsList: Enrolments,
     identifier: String
   ): Option[EnrolmentIdentifier] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
@@ -49,7 +49,7 @@ class AuthActionImpl @Inject() (
   private val logger                                       = Logger(this.getClass)
   private val authTimer                                    = metrics.defaultRegistry.timer("ppt.returns.upstream.auth.timer")
 
-  private def authPredicate = Enrolment("HMRC-PPT-ORG").withDelegatedAuthRule("ppt-auth")
+  private def authPredicate = Enrolment("HMRC-PPT-ORG")
 
   private val authData =
     credentials and name and email and externalId and internalId and affinityGroup and allEnrolments and

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/base/MockAuthAction.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/base/MockAuthAction.scala
@@ -75,10 +75,13 @@ trait MockAuthAction extends MockitoSugar with MetricsMocks {
   val nrsLoginTimes               = LoginTimes(currentLoginTime, Some(previousLoginTime))
 
   // format: off
-  def authorizedUser(user: SignedInUser = exampleUser): Unit =
+  def authorizedUser(user: SignedInUser = exampleUser): Unit = {
+    val delegatedAuthRule = "ppt-auth" // Required for Agent access control; tells auth how the agent access decision is made
+    val enrolmentPredicate = Enrolment("HMRC-PPT-ORG").withDelegatedAuthRule(delegatedAuthRule)
+
     when(
       mockAuthConnector.authorise(
-        any(),
+        ArgumentMatchers.eq(enrolmentPredicate),
         ArgumentMatchers.eq(
           credentials and name and email and externalId and internalId and affinityGroup and allEnrolments
             and agentCode and confidenceLevel and nino and saUtr and dateOfBirth and agentInformation and groupIdentifier and
@@ -150,6 +153,7 @@ trait MockAuthAction extends MockitoSugar with MetricsMocks {
         )
       )
     )
+  }
   // format: on
 
   def unAuthorizedUser(): Unit =

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/base/MockAuthAction.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/base/MockAuthAction.scala
@@ -76,8 +76,7 @@ trait MockAuthAction extends MockitoSugar with MetricsMocks {
 
   // format: off
   def authorizedUser(user: SignedInUser = exampleUser): Unit = {
-    val delegatedAuthRule = "ppt-auth" // Required for Agent access control; tells auth how the agent access decision is made
-    val enrolmentPredicate = Enrolment("HMRC-PPT-ORG").withDelegatedAuthRule(delegatedAuthRule)
+    val enrolmentPredicate = Enrolment("HMRC-PPT-ORG")
 
     when(
       mockAuthConnector.authorise(

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthActionSpec.scala
@@ -103,6 +103,7 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
 
       val result = createAuthAction().invokeBlock(authRequest(Headers(), user), okResponseGenerator)
 
+      status(result) mustBe SEE_OTHER
       redirectLocation(result) mustBe Some(homeRoutes.UnauthorisedController.onPageLoad().url)
     }
 
@@ -183,6 +184,7 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
                                        okResponseGenerator
         )
 
+      status(result) mustBe SEE_OTHER
       redirectLocation(result) mustBe Some(homeRoutes.UnauthorisedController.onPageLoad().url)
     }
   }


### PR DESCRIPTION
### Description of Work carried through

As per #111 but without considerign agents, our auth call should document the need for a PPT enrolment using the auth Enrolment predicate.

This becomes important is this service needs to be enabled for agents in the future.

Doing this now has no user facing effect; re directions to registration for missing enrolments continue to work as normal.


#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed 
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
