### PR TITLE
Enable Agents access to returns

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/config/AppConfig.scala
@@ -73,8 +73,6 @@ class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesCo
   def pptReturnSubmissionUrl(pptReference: String): String =
     s"$pptReturnsSubmissionUrl/$pptReference"
 
-  def pptReturnSubmissionUrl(id: String): String = s"$pptReturnsSubmissionUrl/$id"
-
   def pptSubscriptionUrl(pptReference: String): String =
     s"$pptServiceHost/subscriptions/$pptReference"
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/config/AppConfig.scala
@@ -68,7 +68,10 @@ class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesCo
   lazy val pptReturnsUrl: String           = s"$pptServiceHost/returns"
   lazy val pptReturnsSubmissionUrl: String = s"$pptServiceHost/returns-submission"
 
-  def pptReturnUrl(id: String): String = s"$pptReturnsUrl/$id"
+  def pptReturnUrl(pptReference: String): String = s"$pptReturnsUrl/$pptReference"
+
+  def pptReturnSubmissionUrl(pptReference: String): String =
+    s"$pptReturnsSubmissionUrl/$pptReference"
 
   def pptReturnSubmissionUrl(id: String): String = s"$pptReturnsSubmissionUrl/$id"
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/connectors/ObligationsConnector.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/connectors/ObligationsConnector.scala
@@ -34,20 +34,17 @@ class ObligationsConnector @Inject() (
 
   def get(pptReferenceNumber: String)(implicit hc: HeaderCarrier): Future[PPTObligations] = {
     val timer = metrics.defaultRegistry.timer("ppt.obligations.open.get.timer").time()
-    httpClient.GET[PPTObligations](appConfig.pptObligationUrl(pptReferenceNumber))
-      .map {
-        response =>
-          logger.info(s"Retrieved open obligations for ppt reference number [$pptReferenceNumber]")
-          response
-      }
-      .andThen { case _ => timer.stop() }
-      .recover {
-        case exception: Exception =>
-          throw DownstreamServiceError(
-            s"Failed to retrieve open obligations for PPTReference: [$pptReferenceNumber], error: [${exception.getMessage}]",
-            exception
-          )
-      }
+
+    Future.successful {
+
+      PPTObligations(nextObligation = None,
+                     oldestOverdueObligation = None,
+                     overdueObligationCount = 0,
+                     isNextObligationDue = false,
+                     displaySubmitReturnsLink = true
+      )
+
+    }
   }
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/connectors/ObligationsConnector.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/connectors/ObligationsConnector.scala
@@ -34,17 +34,20 @@ class ObligationsConnector @Inject() (
 
   def get(pptReferenceNumber: String)(implicit hc: HeaderCarrier): Future[PPTObligations] = {
     val timer = metrics.defaultRegistry.timer("ppt.obligations.open.get.timer").time()
-
-    Future.successful {
-
-      PPTObligations(nextObligation = None,
-                     oldestOverdueObligation = None,
-                     overdueObligationCount = 0,
-                     isNextObligationDue = false,
-                     displaySubmitReturnsLink = true
-      )
-
-    }
+    httpClient.GET[PPTObligations](appConfig.pptObligationUrl(pptReferenceNumber))
+      .map {
+        response =>
+          logger.info(s"Retrieved open obligations for ppt reference number [$pptReferenceNumber]")
+          response
+      }
+      .andThen { case _ => timer.stop() }
+      .recover {
+        case exception: Exception =>
+          throw DownstreamServiceError(
+            s"Failed to retrieve open obligations for PPTReference: [$pptReferenceNumber], error: [${exception.getMessage}]",
+            exception
+          )
+      }
   }
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
@@ -92,13 +92,24 @@ class AuthActionImpl @Inject() (
                                           Some(loginTimes)
           )
 
-          getPptEnrolmentId(allEnrolments, pptEnrolmentIdentifierName) match {
-            case None =>
-              throw InsufficientEnrolments(
-                s"key: $pptEnrolmentKey and identifier: $pptEnrolmentIdentifierName is not found"
-              )
-            case Some(pptEnrolmentIdentifier) =>
-              executeRequest(request, block, identityData, pptEnrolmentIdentifier, allEnrolments)
+          affinityGroup match {
+            case Some(AffinityGroup.Agent) =>
+              // prevent agent access while the service is unable to support them
+              Future.successful(Results.PreconditionFailed)
+            case _ =>
+              getPptEnrolmentId(allEnrolments, pptEnrolmentIdentifierName) match {
+                case None =>
+                  throw InsufficientEnrolments(
+                    s"key: $pptEnrolmentKey and identifier: $pptEnrolmentIdentifierName is not found"
+                  )
+                case Some(pptEnrolmentIdentifier) =>
+                  executeRequest(request,
+                                 block,
+                                 identityData,
+                                 pptEnrolmentIdentifier,
+                                 allEnrolments
+                  )
+              }
           }
 
       } recover {

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions
 import com.google.inject.{ImplementedBy, Inject}
 import com.kenshoo.play.metrics.Metrics
 import play.api.Logger
+import play.api.mvc.Results.Redirect
 import play.api.mvc._
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{agentCode, _}
@@ -30,6 +31,7 @@ import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthAction.{
   pptEnrolmentKey
 }
 import uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.{routes => homeRoutes}
+import uk.gov.hmrc.plasticpackagingtax.returns.controllers.agents.{routes => agentRoutes}
 import uk.gov.hmrc.plasticpackagingtax.returns.models.SignedInUser
 import uk.gov.hmrc.plasticpackagingtax.returns.models.request.{AuthenticatedRequest, IdentityData}
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
@@ -95,7 +97,7 @@ class AuthActionImpl @Inject() (
           affinityGroup match {
             case Some(AffinityGroup.Agent) =>
               // prevent agent access while the service is unable to support them
-              Future.successful(Results.PreconditionFailed)
+              Future.successful(Redirect(agentRoutes.AgentsController.displayPage()))
             case _ =>
               getPptEnrolmentId(allEnrolments, pptEnrolmentIdentifierName) match {
                 case None =>

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
@@ -75,9 +75,6 @@ class AuthActionImpl @Inject() (
             confidenceLevel ~ authNino ~ saUtr ~ dateOfBirth ~ agentInformation ~ groupIdentifier ~
             credentialRole ~ mdtpInformation ~ itmpName ~ itmpDateOfBirth ~ itmpAddress ~ credentialStrength ~ loginTimes =>
           authorisation.stop()
-          logger.info(
-            "Authorised with affinity group " + affinityGroup + " and enrolments " + allEnrolments
-          )
 
           val identityData = IdentityData(internalId,
                                           externalId,
@@ -104,8 +101,8 @@ class AuthActionImpl @Inject() (
           affinityGroup match {
             case Some(AffinityGroup.Agent) =>
               selectedClientIdentifier.map { pptEnrolmentIdentifier =>
-                // And agent has authed with a selected client and past the enrolment predicate using that identifier
-                // The identifier can be trusted as good pptEnrolmentIdentifier.
+                // An agent has authed with a selected client and past the enrolment predicate using that identifier
+                // The identifier can be trusted as a good pptEnrolmentIdentifier.
                 executeRequest(request, block, identityData, pptEnrolmentIdentifier, allEnrolments)
               }.getOrElse {
                 // An agent has authed but we can't see a selected client identifier;
@@ -114,7 +111,7 @@ class AuthActionImpl @Inject() (
               }
 
             case _ =>
-              // A non agent has presented; their ppt enrolment will have been returned
+              // A non agent has authed; their ppt enrolment will have been returned
               // from auth as it is a principal enrolment
               getPptEnrolmentId(allEnrolments, pptEnrolmentIdentifierName, None) match {
                 case Some(pptEnrolmentIdentifier) =>
@@ -136,7 +133,7 @@ class AuthActionImpl @Inject() (
         Results.Redirect(appConfig.loginUrl, Map("continue" -> Seq(appConfig.loginContinueUrl)))
 
       case _: InsufficientEnrolments =>
-        // Redirected to the non enrolled page; this is authed by doesn't need enrolments.
+        // Redirect to the non enrolled page; this is authed but doesn't need enrolments.
         // There we can examine the user and determine where to send them.
         Results.Redirect(homeRoutes.UnauthorisedController.notEnrolled())
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
@@ -63,8 +63,8 @@ class AuthActionImpl @Inject() (
     implicit val hc: HeaderCarrier =
       HeaderCarrierConverter.fromRequestAndSession(request, request.session)
 
-    // TODO duplicate but too tied to fight the [A] placeholder just now
-    def getSelectedClientIdentifier(): Option[String] = request.session.get("clientPPT")
+    // In theory this could be deduplicated with SelectedClientIdentifier by the generic makes it too differcult
+    def getSelectedClientIdentifier() = request.session.get("clientPPT")
 
     val authorisation            = authTimer.time()
     val selectedClientIdentifier = getSelectedClientIdentifier()

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
@@ -164,7 +164,7 @@ class AuthActionImpl @Inject() (
     enrolments: Enrolments,
     identifier: String,
     selectedClientIdentifier: Option[String]
-  ): Option[String] = {
+  ): Option[String] =
     // It appears Auth with never return a delegated enrolment in it's response to an agent auth request;
     // therefore we have to use the one the agent past in. This is safe because this identifier has just
     // past auth for this this agent.
@@ -175,7 +175,6 @@ class AuthActionImpl @Inject() (
         case None => Option.empty
       }
     }
-  }
 
   private def getPptEnrolmentIdentifier(
     enrolmentsList: Enrolments,

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
@@ -164,9 +164,10 @@ class AuthActionImpl @Inject() (
     enrolments: Enrolments,
     identifier: String,
     selectedClientIdentifier: Option[String]
-  ): Option[String] =
-    // It appears Auth with never return a delegrated enrolment in
-    // it's response; so we have to use the one we past to the predicate!
+  ): Option[String] = {
+    // It appears Auth with never return a delegated enrolment in it's response to an agent auth request;
+    // therefore we have to use the one the agent past in. This is safe because this identifier has just
+    // past auth for this this agent.
     selectedClientIdentifier.map(Some(_)).getOrElse {
       getPptEnrolmentIdentifier(enrolments, identifier) match {
         case Some(enrolmentIdentifier) =>
@@ -174,6 +175,7 @@ class AuthActionImpl @Inject() (
         case None => Option.empty
       }
     }
+  }
 
   private def getPptEnrolmentIdentifier(
     enrolmentsList: Enrolments,

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAgentAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAgentAction.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions
+
+import com.google.inject.{ImplementedBy, Inject}
+import com.kenshoo.play.metrics.Metrics
+import play.api.Logger
+import play.api.mvc._
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
+import uk.gov.hmrc.auth.core.retrieve.~
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
+import uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.{routes => homeRoutes}
+import uk.gov.hmrc.plasticpackagingtax.returns.models.SignedInUser
+import uk.gov.hmrc.plasticpackagingtax.returns.models.request.{AuthenticatedRequest, IdentityData}
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class AuthAgentActionImpl @Inject() (
+  override val authConnector: AuthConnector,
+  appConfig: AppConfig,
+  metrics: Metrics,
+  mcc: MessagesControllerComponents
+) extends AuthAgentAction with AuthorisedFunctions {
+
+  implicit override val executionContext: ExecutionContext = mcc.executionContext
+  override val parser: BodyParser[AnyContent]              = mcc.parsers.defaultBodyParser
+  private val logger                                       = Logger(this.getClass)
+  private val authTimer                                    = metrics.defaultRegistry.timer("ppt.returns.upstream.auth.timer")
+
+  private val authData =
+    credentials and name and email and externalId and internalId and affinityGroup and allEnrolments and
+      agentCode and confidenceLevel and nino and saUtr and dateOfBirth and agentInformation and groupIdentifier and
+      credentialRole and mdtpInformation and itmpName and itmpDateOfBirth and itmpAddress and credentialStrength and loginTimes
+
+  override def invokeBlock[A](
+    request: Request[A],
+    block: AuthenticatedRequest[A] => Future[Result]
+  ): Future[Result] = {
+    implicit val hc: HeaderCarrier =
+      HeaderCarrierConverter.fromRequestAndSession(request, request.session)
+
+    val authorisation = authTimer.time()
+
+    authorised()
+      .retrieve(authData) {
+        case credentials ~ name ~ email ~ externalId ~ internalId ~ affinityGroup ~ allEnrolments ~ agentCode ~
+            confidenceLevel ~ authNino ~ saUtr ~ dateOfBirth ~ agentInformation ~ groupIdentifier ~
+            credentialRole ~ mdtpInformation ~ itmpName ~ itmpDateOfBirth ~ itmpAddress ~ credentialStrength ~ loginTimes =>
+          authorisation.stop()
+          val identityData = IdentityData(internalId,
+                                          externalId,
+                                          agentCode,
+                                          credentials,
+                                          Some(confidenceLevel),
+                                          authNino,
+                                          saUtr,
+                                          name,
+                                          dateOfBirth,
+                                          email,
+                                          Some(agentInformation),
+                                          groupIdentifier,
+                                          credentialRole.map(res => res.toJson.toString()),
+                                          mdtpInformation,
+                                          itmpName,
+                                          itmpDateOfBirth,
+                                          itmpAddress,
+                                          affinityGroup,
+                                          credentialStrength,
+                                          Some(loginTimes)
+          )
+
+          affinityGroup match {
+            case Some(AffinityGroup.Agent) =>
+              executeRequest(request, block, identityData, allEnrolments)
+            case _ => throw UnsupportedAffinityGroup() // TODO can be pused to the auth predicate?
+          }
+
+      } recover {
+      case _: NoActiveSession =>
+        Results.Redirect(appConfig.loginUrl, Map("continue" -> Seq(appConfig.loginContinueUrl)))
+
+      case _: AuthorisationException =>
+        Results.Redirect(homeRoutes.UnauthorisedController.unauthorised())
+    }
+  }
+
+  private def executeRequest[A](
+    request: Request[A],
+    block: AuthenticatedRequest[A] => Future[Result],
+    identityData: IdentityData,
+    allEnrolments: Enrolments
+  ) = {
+    val pptLoggedInUser = SignedInUser(allEnrolments, identityData)
+    block(new AuthenticatedRequest(request, pptLoggedInUser, None))
+  }
+
+}
+
+object AuthAgentAction {}
+
+@ImplementedBy(classOf[AuthAgentActionImpl])
+trait AuthAgentAction
+    extends ActionBuilder[AuthenticatedRequest, AnyContent]
+    with ActionFunction[Request, AuthenticatedRequest]

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAgentAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAgentAction.scala
@@ -58,7 +58,7 @@ class AuthAgentActionImpl @Inject() (
 
     val authorisation = authTimer.time()
 
-    authorised()
+    authorised(AffinityGroup.Agent)
       .retrieve(authData) {
         case credentials ~ name ~ email ~ externalId ~ internalId ~ affinityGroup ~ allEnrolments ~ agentCode ~
             confidenceLevel ~ authNino ~ saUtr ~ dateOfBirth ~ agentInformation ~ groupIdentifier ~
@@ -86,11 +86,7 @@ class AuthAgentActionImpl @Inject() (
                                           Some(loginTimes)
           )
 
-          affinityGroup match {
-            case Some(AffinityGroup.Agent) =>
-              executeRequest(request, block, identityData, allEnrolments)
-            case _ => throw UnsupportedAffinityGroup() // TODO can be pused to the auth predicate?
-          }
+          executeRequest(request, block, identityData, allEnrolments)
 
       } recover {
       case _: NoActiveSession =>

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthCheckAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthCheckAction.scala
@@ -21,6 +21,7 @@ import com.kenshoo.play.metrics.Metrics
 import play.api.Logger
 import play.api.mvc._
 import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
 import uk.gov.hmrc.auth.core.retrieve.~
 import uk.gov.hmrc.http.HeaderCarrier
@@ -58,7 +59,7 @@ class AuthCheckActionImpl @Inject() (
 
     val authorisation = authTimer.time()
 
-    authorised()
+    authorised(EmptyPredicate)
       .retrieve(authData) {
         case credentials ~ name ~ email ~ externalId ~ internalId ~ affinityGroup ~ allEnrolments ~ agentCode ~
             confidenceLevel ~ authNino ~ saUtr ~ dateOfBirth ~ agentInformation ~ groupIdentifier ~

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/agents/AgentsController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/agents/AgentsController.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.returns.controllers.agents
+
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.returns.models.request.JourneyAction
+import uk.gov.hmrc.plasticpackagingtax.returns.views.html.agents.agents_page
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class AgentsController @Inject() (
+  authenticate: AuthAction,
+  journeyAction: JourneyAction,
+  mcc: MessagesControllerComponents,
+  page: agents_page
+)(implicit ec: ExecutionContext)
+    extends FrontendController(mcc) with I18nSupport {
+
+  val displayPage: Action[AnyContent] = Action.async { implicit request =>
+    Future.successful(Ok(page()))
+  }
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/agents/AgentsController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/agents/AgentsController.scala
@@ -46,12 +46,11 @@ class AgentsController @Inject() (
 
   val submit: Action[AnyContent] =
     authenticate { implicit request =>
-      // Catch client identifier; validate and stash somewhere accessible pre auth and only to this user
       ClientIdentifier.form()
         .bindFromRequest()
         .fold((formWithErrors: Form[ClientIdentifier]) => BadRequest(page(formWithErrors)),
               clientIdentifier =>
-                // Set this on the session and then redirect account
+                // Set this on the session and then redirect to account page to attempt to auth with it
                 appendSelectedClientIdentifierToResult(
                   clientIdentifier,
                   Redirect(homeRoutes.HomeController.displayPage())

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/agents/AgentsController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/agents/AgentsController.scala
@@ -16,9 +16,11 @@
 
 package uk.gov.hmrc.plasticpackagingtax.returns.controllers.agents
 
+import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.returns.forms.agents.ClientIdentifier
 import uk.gov.hmrc.plasticpackagingtax.returns.models.request.JourneyAction
 import uk.gov.hmrc.plasticpackagingtax.returns.views.html.agents.agents_page
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -35,7 +37,23 @@ class AgentsController @Inject() (
     extends FrontendController(mcc) with I18nSupport {
 
   val displayPage: Action[AnyContent] = Action.async { implicit request =>
-    Future.successful(Ok(page()))
+    // TODO needs to be wrapped in an agents only auth
+    val form = ClientIdentifier.form().fill(ClientIdentifier(""))
+    Future.successful(Ok(page(form)))
+  }
+
+  val submit: Action[AnyContent] = Action.async { implicit request =>
+    // TODO needs to be wrapped in an agents only auth
+    // Catch client identifier; validate and stash somewhere accessible pre auth and only to this user
+    ClientIdentifier.form()
+      .bindFromRequest()
+      .fold(
+        (formWithErrors: Form[ClientIdentifier]) =>
+          Future.successful(BadRequest(page(formWithErrors))),
+        clientIdentifier =>
+          // Set this on the session and then redirect account
+          Future.successful(Ok("Got client identifier: " + clientIdentifier.identifier))
+      )
   }
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/agents/AgentsController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/agents/AgentsController.scala
@@ -20,28 +20,25 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.{routes => homeRoutes}
 import uk.gov.hmrc.plasticpackagingtax.returns.forms.agents.ClientIdentifier
 import uk.gov.hmrc.plasticpackagingtax.returns.models.request.JourneyAction
 import uk.gov.hmrc.plasticpackagingtax.returns.views.html.agents.agents_page
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
-import uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.{routes => homeRoutes}
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class AgentsController @Inject() (
   authenticate: AuthAction,
-  journeyAction: JourneyAction,
   mcc: MessagesControllerComponents,
   page: agents_page
 )(implicit ec: ExecutionContext)
-    extends FrontendController(mcc) with I18nSupport {
-
-  val clientIdentifierSessionKey = "clientPPT"
+    extends FrontendController(mcc) with I18nSupport with SelectedClientIdentifier {
 
   val displayPage: Action[AnyContent] = Action.async { implicit request =>
     // TODO needs to be wrapped in an agents only auth
-    val currentlySelectedClientIdentifier = request.session.get(clientIdentifierSessionKey)
+    val currentlySelectedClientIdentifier = getSelectedClientIdentifierFrom(request)
     val form = ClientIdentifier.form().fill(
       ClientIdentifier(currentlySelectedClientIdentifier.getOrElse(""))
     )
@@ -56,15 +53,13 @@ class AgentsController @Inject() (
       .fold(
         (formWithErrors: Form[ClientIdentifier]) =>
           Future.successful(BadRequest(page(formWithErrors))),
-        {
-          clientIdentifier =>
-            // Set this on the session and then redirect account
-            val sessionValues: Seq[(String, String)] =
-              Seq(clientIdentifierSessionKey -> clientIdentifier.identifier)
-            Future.successful(
-              Redirect(homeRoutes.HomeController.displayPage()).addingToSession(sessionValues: _*)
+        clientIdentifier =>
+          // Set this on the session and then redirect account
+          Future.successful {
+            appendSelectedClientIdentifierToResult(clientIdentifier,
+                                                   Redirect(homeRoutes.HomeController.displayPage())
             )
-        }
+          }
       )
   }
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/agents/AgentsController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/agents/AgentsController.scala
@@ -22,7 +22,6 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthAction
 import uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.{routes => homeRoutes}
 import uk.gov.hmrc.plasticpackagingtax.returns.forms.agents.ClientIdentifier
-import uk.gov.hmrc.plasticpackagingtax.returns.models.request.JourneyAction
 import uk.gov.hmrc.plasticpackagingtax.returns.views.html.agents.agents_page
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/agents/SelectedClientIdentifier.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/agents/SelectedClientIdentifier.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.returns.controllers.agents
+
+import play.api.mvc.{AnyContent, Request, Result}
+import uk.gov.hmrc.plasticpackagingtax.returns.forms.agents.ClientIdentifier
+
+trait SelectedClientIdentifier {
+
+  private val clientIdentifierSessionKey = "clientPPT"
+
+  def getSelectedClientIdentifierFrom(request: Request[AnyContent]): Option[String] =
+    request.session.get(clientIdentifierSessionKey)
+
+  def appendSelectedClientIdentifierToResult(clientIdentifier: ClientIdentifier, result: Result)(
+    implicit request: Request[AnyContent]
+  ): Result = {
+    val sessionValues: Seq[(String, String)] =
+      Seq(clientIdentifierSessionKey -> clientIdentifier.identifier)
+    result.addingToSession(sessionValues: _*)
+  }
+
+  // TODO This possibly needs to be cleared down; see Self Assessment for prior art
+  def cleanSelectedClientIdentifier = ???
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/agents/SelectedClientIdentifier.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/agents/SelectedClientIdentifier.scala
@@ -34,7 +34,4 @@ trait SelectedClientIdentifier {
     result.addingToSession(sessionValues: _*)
   }
 
-  // TODO This possibly needs to be cleared down; see Self Assessment for prior art
-  def cleanSelectedClientIdentifier = ???
-
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/forms/CommonFormValidators.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/forms/CommonFormValidators.scala
@@ -54,13 +54,15 @@ trait CommonFormValidators {
   val isLowerOrEqualTo: BigDecimal => String => Boolean = (threshold: BigDecimal) =>
     (input: String) => isValidDecimal(input) && BigDecimal(input.trim) <= threshold
 
+  val isLength: (String, Int) => Boolean = (value, length) => value.trim.length == length
+
   val isNotExceedingMaxLength: (String, Int) => Boolean = (value, maxLength) =>
     value.trim.length <= maxLength
 
   val isValidName: String => Boolean = (name: String) =>
     name.isEmpty || isMatchingPattern(name, namePattern)
 
-  private val isMatchingPattern: (String, Pattern) => Boolean = (value, pattern) =>
+  protected val isMatchingPattern: (String, Pattern) => Boolean = (value, pattern) =>
     pattern.matcher(value).matches()
 
   private val namePattern =

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/forms/agents/ClientIdentifier.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/forms/agents/ClientIdentifier.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.plasticpackagingtax.returns.forms.agents
 
-import play.api.data.{Form, Mapping}
+import play.api.data.Form
 import play.api.data.Forms.{mapping, text}
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.plasticpackagingtax.returns.forms.CommonFormValidators

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/forms/agents/ClientIdentifier.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/forms/agents/ClientIdentifier.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.returns.forms.agents
+
+import play.api.data.{Form, Mapping}
+import play.api.data.Forms.{mapping, text}
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.plasticpackagingtax.returns.forms.CommonFormValidators
+
+case class ClientIdentifier(identifier: String)
+
+object ClientIdentifier extends CommonFormValidators {
+
+  implicit val format: OFormat[ClientIdentifier] = Json.format[ClientIdentifier]
+
+  val identifier           = "identifier"
+  val identifierEmptyError = "agents.client.identifier.empty.error"
+
+  def form(): Form[ClientIdentifier] = {
+    val m: Mapping[ClientIdentifier] = mapping(
+      identifier -> text()
+        .verifying(identifierEmptyError, isNonEmpty)
+    )(ClientIdentifier.apply)(ClientIdentifier.unapply)
+
+    Form(mapping = m)
+  }
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/forms/agents/ClientIdentifier.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/forms/agents/ClientIdentifier.scala
@@ -30,13 +30,14 @@ object ClientIdentifier extends CommonFormValidators {
   val identifier           = "identifier"
   val identifierEmptyError = "agents.client.identifier.empty.error"
 
-  def form(): Form[ClientIdentifier] = {
-    val m: Mapping[ClientIdentifier] = mapping(
-      identifier -> text()
-        .verifying(identifierEmptyError, isNonEmpty)
-    )(ClientIdentifier.apply)(ClientIdentifier.unapply)
-
-    Form(mapping = m)
-  }
+  def form(): Form[ClientIdentifier] =
+    Form(mapping =
+      mapping(
+        identifier -> text()
+          .verifying(identifierEmptyError,
+                     isNonEmpty
+          ) // TODO format and over length protection needed
+      )(ClientIdentifier.apply)(ClientIdentifier.unapply)
+    )
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/forms/agents/ClientIdentifier.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/forms/agents/ClientIdentifier.scala
@@ -21,6 +21,8 @@ import play.api.data.Forms.{mapping, text}
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.plasticpackagingtax.returns.forms.CommonFormValidators
 
+import java.util.regex.Pattern
+
 case class ClientIdentifier(identifier: String)
 
 object ClientIdentifier extends CommonFormValidators {
@@ -29,14 +31,18 @@ object ClientIdentifier extends CommonFormValidators {
 
   val identifier           = "identifier"
   val identifierEmptyError = "agents.client.identifier.empty.error"
+  val formatError          = "agents.client.identifier.format.error"
+  val lengthError          = "agents.client.identifier.length.error"
+
+  private val validFormatPattern = Pattern.compile("^XMPPT\\d{10}$")
 
   def form(): Form[ClientIdentifier] =
     Form(mapping =
       mapping(
         identifier -> text()
-          .verifying(identifierEmptyError,
-                     isNonEmpty
-          ) // TODO format and over length protection needed
+          .verifying(identifierEmptyError, isNonEmpty)
+          .verifying(lengthError, isLength(_, 15))
+          .verifying(formatError, isMatchingPattern(_, validFormatPattern))
       )(ClientIdentifier.apply)(ClientIdentifier.unapply)
     )
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/forms/agents/ClientIdentifier.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/forms/agents/ClientIdentifier.scala
@@ -34,7 +34,7 @@ object ClientIdentifier extends CommonFormValidators {
   val formatError          = "agents.client.identifier.format.error"
   val lengthError          = "agents.client.identifier.length.error"
 
-  private val validFormatPattern = Pattern.compile("^XMPPT\\d{10}$")
+  private val validFormatPattern = Pattern.compile("^X[A-Z]PPT000[0-9]{7}$")
 
   def form(): Form[ClientIdentifier] =
     Form(mapping =

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/agents/agents_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/agents/agents_page.scala.html
@@ -20,18 +20,47 @@
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.html.components.{card, cardSection, link, pageTitle, paragraph, sectionHeader}
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.html.main_template
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.model.Title
+@import play.api.data.Form
+@import uk.gov.hmrc.plasticpackagingtax.returns.forms.agents.ClientIdentifier
+@import uk.gov.hmrc.plasticpackagingtax.returns.views.html.components.saveAndContinue
+@import uk.gov.hmrc.plasticpackagingtax.returns.controllers.agents.{routes => agentRoutes}
 
 @this(
-govukLayout: main_template,
-pageTitle: pageTitle,
-sectionHeader: sectionHeader,
-paragraph: paragraph,
-card: card,
-cardSection: cardSection
+ govukLayout: main_template,
+ pageTitle: pageTitle,
+ sectionHeader: sectionHeader,
+ paragraph: paragraph,
+ card: card,
+ cardSection: cardSection,
+ formHelper: FormWithCSRF,
+ govukInput: GovukInput,
+ saveAndContinue: saveAndContinue
 )
 
-@()(implicit request: Request[_], messages: Messages)
+@(form: Form[ClientIdentifier])(implicit request: Request[_], messages: Messages)
+@totalWeightField = @{form("identifier")}
+@hintContent = {
+ <p class="govuk-body-m">@messages("account.agents.selectClient.hint.body")</p>
+ <p class="govuk-label govuk-label--s">@messages("account.agents.selectClient.hint.label")</p>
+}
 
-@govukLayout(title = Title("returns.startPage.title")) {
- <h2 class="govuk-heading-m">@messages("account.agents.nonSupported.header")</h2>
+@govukLayout(title = Title("account.agents.selectClient.header")) {
+ @formHelper(action = agentRoutes.AgentsController.submit(), 'autoComplete -> "off") {
+  @govukInput(
+   Input(
+    id = s"${totalWeightField.name}",
+    name = totalWeightField.name,
+    value = totalWeightField.value,
+    hint = Some(Hint(content = HtmlContent(hintContent))),
+    errorMessage = totalWeightField.error.map(err => ErrorMessage(content = Text(messages(err.message)))),
+    label = Label(
+      isPageHeading = true,
+      classes = s"govuk-label--l",
+      content = Text(messages("account.agents.selectClient.header"))),
+      spellcheck = Some(false)
+    )
+  )
+  @saveAndContinue()
+ }
+
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/agents/agents_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/agents/agents_page.scala.html
@@ -1,0 +1,37 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
+@import uk.gov.hmrc.plasticpackagingtax.returns.models.request.JourneyRequest
+@import uk.gov.hmrc.plasticpackagingtax.returns.models.subscription.subscriptionDisplay.SubscriptionDisplayResponse
+@import uk.gov.hmrc.plasticpackagingtax.returns.views.html.components.{card, cardSection, link, pageTitle, paragraph, sectionHeader}
+@import uk.gov.hmrc.plasticpackagingtax.returns.views.html.main_template
+@import uk.gov.hmrc.plasticpackagingtax.returns.views.model.Title
+
+@this(
+govukLayout: main_template,
+pageTitle: pageTitle,
+sectionHeader: sectionHeader,
+paragraph: paragraph,
+card: card,
+cardSection: cardSection
+)
+
+@()(implicit request: Request[_], messages: Messages)
+
+@govukLayout(title = Title("returns.startPage.title")) {
+ <h2 class="govuk-heading-m">@messages("account.agents.nonSupported.header")</h2>
+}

--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ lazy val scoverageSettings: Seq[Setting[_]] = Seq(
                                    ".*(BuildInfo|Routes|Options).*",
                                    "logger.*\\(.*\\)"
   ).mkString(";"),
-  coverageMinimum := 70.0,
+  coverageMinimum := 94.0,
   coverageFailOnMinimum := true,
   coverageHighlighting := true,
   parallelExecution in Test := false

--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ lazy val scoverageSettings: Seq[Setting[_]] = Seq(
                                    ".*(BuildInfo|Routes|Options).*",
                                    "logger.*\\(.*\\)"
   ).mkString(";"),
-  coverageMinimum := 94.0,
+  coverageMinimum := 70.0,
   coverageFailOnMinimum := true,
   coverageHighlighting := true,
   parallelExecution in Test := false

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -14,3 +14,5 @@ GET        /assets/*file                                controllers.Assets.versi
 #Welsh Translation
 GET        /lang/enGb                                   uk.gov.hmrc.plasticpackagingtax.returns.controllers.LanguageController.enGb()
 GET        /lang/cyGb                                   uk.gov.hmrc.plasticpackagingtax.returns.controllers.LanguageController.cyGb()
+
+GET        /agents                                      uk.gov.hmrc.plasticpackagingtax.returns.controllers.agents.AgentsController.displayPage()

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -16,3 +16,4 @@ GET        /lang/enGb                                   uk.gov.hmrc.plasticpacka
 GET        /lang/cyGb                                   uk.gov.hmrc.plasticpackagingtax.returns.controllers.LanguageController.cyGb()
 
 GET        /agents                                      uk.gov.hmrc.plasticpackagingtax.returns.controllers.agents.AgentsController.displayPage()
+POST       /agents                                      uk.gov.hmrc.plasticpackagingtax.returns.controllers.agents.AgentsController.submit()

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -134,7 +134,7 @@ assets {
 urls {
   exitSurvey = "http://localhost:9514/feedback/plastic-packaging-tax-registration"
   login = "http://localhost:9949/auth-login-stub/gg-sign-in"
-  loginContinue = "http://localhost:8505/plastic-packaging-tax/submit-return-for-plastic-packaging-tax/submit-return"
+  loginContinue = "http://localhost:8505/plastic-packaging-tax/account"
   feedback = {
     authenticatedLink = "http://localhost:9250/contact/beta-feedback"
     unauthenticatedLink = "http://localhost:9250/contact/beta-feedback-unauthenticated"

--- a/conf/home.routes
+++ b/conf/home.routes
@@ -11,4 +11,5 @@ POST       /contact-name            uk.gov.hmrc.plasticpackagingtax.returns.cont
 GET        /sign-out                uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.SignOutController.signOut(signOutReason: uk.gov.hmrc.plasticpackagingtax.returns.views.model.SignOutReason)
 GET        /we-sign-you-out         uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.SignOutController.sessionTimeoutSignedOut()
 
-GET        /user-unauthorised       uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.UnauthorisedController.onPageLoad()
+GET        /user-unauthorised       uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.UnauthorisedController.unauthorised()
+GET        /not-enrolled       uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.UnauthorisedController.notEnrolled()

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -48,12 +48,12 @@ timeoutDialog.signout.text= Sign out
 title.format={0} - {1} - GOV.UK
 title.withSection.format={0} - {1} - {2} - GOV.UK
 
-account.agents.selectClient.header=Tell us which client you wish to access
-account.agents.selectClient.hint.label=Client Identifier
-account.agents.selectClient.hint.body=The client identifier probably looks something like XMPPT0000000001
-agents.client.identifier.empty.error=Client identifier must be supplied and non blank
-agents.client.identifier.format.error=A client identifier should be XMPTT followed by 10 digits
-agents.client.identifier.length.error=Client identifier should be 15 characters in length
+account.agents.selectClient.header=What is your client’s PPT reference?
+account.agents.selectClient.hint.label=Client PPT reference
+account.agents.selectClient.hint.body=This is the 15 character reference they received when they registered for PPT. For example, XMPPT0001234567.
+agents.client.identifier.empty.error=Client PPT reference must be supplied and non blank
+agents.client.identifier.length.error=Client PPT reference should be 15 characters in length
+agents.client.identifier.format.error=A client PPT reference should start with XMPTT and contain 10 digits
 
 account.homePage.title = Your Plastic Packaging Tax account
 account.homePage.registrationNumber = PPT registration number: {0}

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -53,7 +53,7 @@ account.agents.selectClient.hint.label=Client PPT reference
 account.agents.selectClient.hint.body=This is the 15 character reference they received when they registered for PPT. For example, XMPPT0001234567.
 agents.client.identifier.empty.error=Client PPT reference must be supplied and non blank
 agents.client.identifier.length.error=Client PPT reference should be 15 characters in length
-agents.client.identifier.format.error=A client PPT reference should start with XMPTT and contain 10 digits
+agents.client.identifier.format.error=A client PPT reference should be 15 characters long and start with X
 
 account.homePage.title = Your Plastic Packaging Tax account
 account.homePage.registrationNumber = PPT registration number: {0}

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -48,7 +48,10 @@ timeoutDialog.signout.text= Sign out
 title.format={0} - {1} - GOV.UK
 title.withSection.format={0} - {1} - {2} - GOV.UK
 
-account.agents.nonSupported.header=Agents access to PPT accounts is not currently supported
+account.agents.selectClient.header=Tell us which client you wish to access
+account.agents.selectClient.hint.label=Client Identifier
+account.agents.selectClient.hint.body=The client identifier probably looks something like XMPPT0000000001
+agents.client.identifier.empty.error=Client identifier must be supplied and non blank
 
 account.homePage.title = Your Plastic Packaging Tax account
 account.homePage.registrationNumber = PPT registration number: {0}

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -48,6 +48,8 @@ timeoutDialog.signout.text= Sign out
 title.format={0} - {1} - GOV.UK
 title.withSection.format={0} - {1} - {2} - GOV.UK
 
+account.agents.nonSupported.header=Agents access to PPT accounts is not currently supported
+
 account.homePage.title = Your Plastic Packaging Tax account
 account.homePage.registrationNumber = PPT registration number: {0}
 account.homePage.organisation.group = {0} (representative organisation for group)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -52,6 +52,8 @@ account.agents.selectClient.header=Tell us which client you wish to access
 account.agents.selectClient.hint.label=Client Identifier
 account.agents.selectClient.hint.body=The client identifier probably looks something like XMPPT0000000001
 agents.client.identifier.empty.error=Client identifier must be supplied and non blank
+agents.client.identifier.format.error=A client identifier should be XMPTT followed by 10 digits
+agents.client.identifier.length.error=Client identifier should be 15 characters in length
 
 account.homePage.title = Your Plastic Packaging Tax account
 account.homePage.registrationNumber = PPT registration number: {0}

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/base/MockAuthAction.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/base/MockAuthAction.scala
@@ -75,9 +75,7 @@ trait MockAuthAction extends MockitoSugar with MetricsMocks {
   val nrsLoginTimes               = LoginTimes(currentLoginTime, Some(previousLoginTime))
 
   // format: off
-  def authorizedUser(user: SignedInUser = exampleUser): Unit = {
-    val enrolmentPredicate = Enrolment("HMRC-PPT-ORG")
-
+  def authorizedUser(user: SignedInUser = exampleUser, enrolmentPredicate: Enrolment= Enrolment("HMRC-PPT-ORG")): Unit = {
     when(
       mockAuthConnector.authorise(
         ArgumentMatchers.eq(enrolmentPredicate),

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/base/MockAuthAction.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/base/MockAuthAction.scala
@@ -30,7 +30,10 @@ import uk.gov.hmrc.auth.core.retrieve._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
 import uk.gov.hmrc.plasticpackagingtax.returns.base.PptTestData.{newUser, pptEnrolment}
 import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
-import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.{AuthActionImpl, PptReferenceAllowedList}
+import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.{
+  AuthActionImpl,
+  PptReferenceAllowedList
+}
 import uk.gov.hmrc.plasticpackagingtax.returns.models.SignedInUser
 
 import scala.concurrent.Future

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/base/MockAuthAction.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/base/MockAuthAction.scala
@@ -25,14 +25,12 @@ import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers.stubMessagesControllerComponents
 import uk.gov.hmrc.auth.core.AffinityGroup.Individual
 import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.authorise.Predicate
 import uk.gov.hmrc.auth.core.retrieve._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
 import uk.gov.hmrc.plasticpackagingtax.returns.base.PptTestData.{newUser, pptEnrolment}
 import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
-import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.{
-  AuthActionImpl,
-  PptReferenceAllowedList
-}
+import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.{AuthActionImpl, PptReferenceAllowedList}
 import uk.gov.hmrc.plasticpackagingtax.returns.models.SignedInUser
 
 import scala.concurrent.Future
@@ -75,10 +73,10 @@ trait MockAuthAction extends MockitoSugar with MetricsMocks {
   val nrsLoginTimes               = LoginTimes(currentLoginTime, Some(previousLoginTime))
 
   // format: off
-  def authorizedUser(user: SignedInUser = exampleUser, enrolmentPredicate: Enrolment= Enrolment("HMRC-PPT-ORG")): Unit = {
+  def authorizedUser(user: SignedInUser = exampleUser, requiredPredicate: Predicate = Enrolment("HMRC-PPT-ORG")): Unit = {
     when(
       mockAuthConnector.authorise(
-        ArgumentMatchers.eq(enrolmentPredicate),
+        ArgumentMatchers.eq(requiredPredicate),
         ArgumentMatchers.eq(
           credentials and name and email and externalId and internalId and affinityGroup and allEnrolments
             and agentCode and confidenceLevel and nino and saUtr and dateOfBirth and agentInformation and groupIdentifier and

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/base/PptTestData.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/base/PptTestData.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.plasticpackagingtax.returns.base
 import org.joda.time.{DateTime, LocalDate}
 import uk.gov.hmrc.auth.core.ConfidenceLevel.L50
 import uk.gov.hmrc.auth.core.retrieve.{AgentInformation, Credentials, LoginTimes, Name}
-import uk.gov.hmrc.auth.core.{Enrolment, Enrolments}
+import uk.gov.hmrc.auth.core.{AffinityGroup, Enrolment, Enrolments}
 import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthAction
 import uk.gov.hmrc.plasticpackagingtax.returns.models.request.IdentityData
 import uk.gov.hmrc.plasticpackagingtax.returns.models.subscription._
@@ -106,7 +106,8 @@ object PptTestData {
 
   def newUser(
     externalId: String = "123",
-    enrolments: Option[Enrolments] = Some(pptEnrolment("123"))
+    enrolments: Option[Enrolments] = Some(pptEnrolment("123")),
+    affinityGroup: Option[AffinityGroup] = None
   ): SignedInUser =
     SignedInUser(enrolments.getOrElse(Enrolments(Set())),
                  IdentityData(Some("Int-ba17b467-90f3-42b6-9570-73be7b78eb2b"),
@@ -131,11 +132,14 @@ object PptTestData {
                               None,
                               None,
                               None,
-                              None,
+                              affinityGroup,
                               Some("crdentialStrength 50"),
                               Some(LoginTimes(DateTime.now, None))
                  )
     )
+
+  def newAgent(externalId: String = "123") =
+    newUser(externalId, enrolments = None, affinityGroup = Some(AffinityGroup.Agent))
 
   def pptEnrolment(pptEnrolmentId: String) =
     newEnrolments(

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/base/unit/ControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/base/unit/ControllerSpec.scala
@@ -62,15 +62,23 @@ trait ControllerSpec
 
   def authRequest(
     headers: Headers = Headers(),
-    user: SignedInUser = PptTestData.newUser("123", Some(pptEnrolment("333")))
-  ): AuthenticatedRequest[AnyContentAsEmpty.type] =
+    user: SignedInUser = PptTestData.newUser("123", Some(pptEnrolment("333"))),
+    pptClient: Option[String] = None
+  ): AuthenticatedRequest[AnyContentAsEmpty.type] = {
+    val request = pptClient.map { clientIdentifier =>
+      FakeRequest().withHeaders(headers).withSession(("clientPPT", clientIdentifier))
+    }.getOrElse {
+      FakeRequest().withHeaders(headers)
+    }
+
     new AuthenticatedRequest(
-      FakeRequest().withHeaders(headers),
+      request,
       user,
       user.enrolments.getEnrolment(AuthAction.pptEnrolmentKey).flatMap(
         e => e.getIdentifier(AuthAction.pptEnrolmentIdentifierName).map(i => i.value)
       )
     )
+  }
 
   protected def postRequestEncoded(
     form: AnyRef,

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthActionSpec.scala
@@ -65,6 +65,16 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
       redirectLocation(result) mustBe Some(homeRoutes.UnauthorisedController.onPageLoad().url)
     }
 
+    "fail if an agent tries to access this non agent aware service" in {
+      val agent = PptTestData.newAgent("456")
+      authorizedUser(agent)
+
+      val result =
+        createAuthAction().invokeBlock(authRequest(Headers(), agent), okResponseGenerator)
+
+      status(result) mustBe PRECONDITION_FAILED
+    }
+
     "process request when enrolment id is present" in {
       val user = PptTestData.newUser("123", Some(pptEnrolment("555")))
       authorizedUser(user)

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthActionSpec.scala
@@ -21,11 +21,18 @@ import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import play.api.mvc.{Headers, Results}
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.{InternalError, MissingBearerToken}
-import uk.gov.hmrc.plasticpackagingtax.returns.base.PptTestData.{newEnrolment, newEnrolments, pptEnrolment}
+import uk.gov.hmrc.plasticpackagingtax.returns.base.PptTestData.{
+  newEnrolment,
+  newEnrolments,
+  pptEnrolment
+}
 import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.ControllerSpec
 import uk.gov.hmrc.plasticpackagingtax.returns.base.{MetricsMocks, PptTestData}
 import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
-import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthAction.{pptEnrolmentIdentifierName, pptEnrolmentKey}
+import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthAction.{
+  pptEnrolmentIdentifierName,
+  pptEnrolmentKey
+}
 import uk.gov.hmrc.plasticpackagingtax.returns.controllers.agents.{routes => agentRoutes}
 import uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.{routes => homeRoutes}
 import uk.gov.hmrc.plasticpackagingtax.returns.models.request.AuthenticatedRequest
@@ -55,7 +62,7 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
       authorizedUser(user)
 
       val result = createAuthAction().invokeBlock(authRequest(Headers(), user), okResponseGenerator)
-
+unauthorised
       redirectLocation(result) mustBe Some(homeRoutes.UnauthorisedController.notEnrolled().url)
     }
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthActionSpec.scala
@@ -57,13 +57,13 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
 
   "Auth Action" should {
 
-    "redirect to unauthorised page when enrolment id is missing" in {
+    "redirect to not enrolled page when enrolment id is missing" in {
       val user = PptTestData.newUser("123", Some(pptEnrolment("")))
       authorizedUser(user)
 
       val result = createAuthAction().invokeBlock(authRequest(Headers(), user), okResponseGenerator)
 
-      redirectLocation(result) mustBe Some(homeRoutes.UnauthorisedController.onPageLoad().url)
+      redirectLocation(result) mustBe Some(homeRoutes.UnauthorisedController.notEnrolled().url)
     }
 
     "redirect to an agent specific sorry page to access this non agent aware service" in {
@@ -116,7 +116,7 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
       val result = createAuthAction().invokeBlock(authRequest(Headers(), user), okResponseGenerator)
 
       status(result) mustBe SEE_OTHER
-      redirectLocation(result) mustBe Some(homeRoutes.UnauthorisedController.onPageLoad().url)
+      redirectLocation(result) mustBe Some(homeRoutes.UnauthorisedController.unauthorised().url)
     }
 
     "redirect to unauthorised page when enrolment id is present but no ppt enrolment key found" in {
@@ -135,7 +135,7 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
 
       val result = createAuthAction().invokeBlock(authRequest(Headers(), user), okResponseGenerator)
 
-      redirectLocation(result) mustBe Some(homeRoutes.UnauthorisedController.onPageLoad().url)
+      redirectLocation(result) mustBe Some(homeRoutes.UnauthorisedController.unauthorised().url)
     }
 
     "time calls to authorisation" in {
@@ -169,7 +169,7 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
           okResponseGenerator
         )
 
-      redirectLocation(result) mustBe Some(homeRoutes.UnauthorisedController.onPageLoad().url)
+      redirectLocation(result) mustBe Some(homeRoutes.UnauthorisedController.unauthorised().url)
     }
 
     "redirect when user not logged in" in {
@@ -197,7 +197,7 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
         )
 
       status(result) mustBe SEE_OTHER
-      redirectLocation(result) mustBe Some(homeRoutes.UnauthorisedController.onPageLoad().url)
+      redirectLocation(result) mustBe Some(homeRoutes.UnauthorisedController.unauthorised().url)
     }
   }
 }

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthActionSpec.scala
@@ -87,11 +87,11 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
 
     "process request when an authorised client identifier is seen on an agents session" in {
       val agent = PptTestData.newAgent("456")
-      val agentEnrolmentPredicate =
+      val agentDelegatedAuthPredicate =
         Enrolment("HMRC-PPT-ORG").withIdentifier(pptEnrolmentIdentifierName,
                                                  "XMPPT0000000123"
         ).withDelegatedAuthRule("ppt-auth")
-      authorizedUser(agent, enrolmentPredicate = agentEnrolmentPredicate)
+      authorizedUser(agent, requiredPredicate = agentDelegatedAuthPredicate)
       await(
         createAuthAction().invokeBlock(authRequest(Headers(), agent, Some("XMPPT0000000123")),
                                        okResponseGenerator

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthActionSpec.scala
@@ -35,6 +35,7 @@ import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthAction.{
 }
 import uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.{routes => homeRoutes}
 import uk.gov.hmrc.plasticpackagingtax.returns.models.request.AuthenticatedRequest
+import uk.gov.hmrc.plasticpackagingtax.returns.controllers.agents.{routes => agentRoutes}
 
 import scala.concurrent.Future
 
@@ -65,14 +66,15 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
       redirectLocation(result) mustBe Some(homeRoutes.UnauthorisedController.onPageLoad().url)
     }
 
-    "fail if an agent tries to access this non agent aware service" in {
+    "redirect to an agent specific sorry page to access this non agent aware service" in {
       val agent = PptTestData.newAgent("456")
       authorizedUser(agent)
 
       val result =
         createAuthAction().invokeBlock(authRequest(Headers(), agent), okResponseGenerator)
 
-      status(result) mustBe PRECONDITION_FAILED
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(agentRoutes.AgentsController.displayPage().url)
     }
 
     "process request when enrolment id is present" in {

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/agents/AgentsControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/agents/AgentsControllerSpec.scala
@@ -14,47 +14,46 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.plasticpackagingtax.returns.controllers.home
+package uk.gov.hmrc.plasticpackagingtax.returns.controllers.agents
 
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, when}
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
-import play.api.test.Helpers._
+import play.api.http.Status.OK
+import play.api.test.Helpers.{status, stubMessagesControllerComponents}
 import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.auth.core.AffinityGroup
+import uk.gov.hmrc.plasticpackagingtax.returns.base.PptTestData
 import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.ControllerSpec
-import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthCheckActionImpl
-import uk.gov.hmrc.plasticpackagingtax.returns.views.html.home.unauthorised
+import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthAgentActionImpl
+import uk.gov.hmrc.plasticpackagingtax.returns.views.html.agents.agents_page
 
-class UnauthorisedControllerSpec extends ControllerSpec {
+class AgentsControllerSpec extends ControllerSpec {
 
-  private val page = mock[unauthorised]
+  private val mcc  = stubMessagesControllerComponents()
+  private val page = mock[agents_page]
 
-  val mockAuthCheckAction = new AuthCheckActionImpl(mockAuthConnector,
+  val mockAuthAgentAction = new AuthAgentActionImpl(mockAuthConnector,
                                                     config,
                                                     metricsMock,
                                                     stubMessagesControllerComponents()
   )
 
-  val controller =
-    new UnauthorisedController(mockAuthCheckAction, stubMessagesControllerComponents(), page)
+  private val controller =
+    new AgentsController(authenticate = mockAuthAgentAction, mcc = mcc, page = page)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
-    when(page.apply()(any(), any())).thenReturn(HtmlFormat.empty)
+    when(page.apply(any())(any(),any())).thenReturn(HtmlFormat.empty)
   }
 
-  override protected def afterEach(): Unit = {
-    reset(page)
-    super.afterEach()
-  }
+  "Agents Controller" should {
+    "return 200" when {
+      "agent is authorised and display select client page is requested" in {
+        val agent = PptTestData.newAgent("456")
+        authorizedUser(agent, requiredPredicate = AffinityGroup.Agent)
 
-  "Unauthorised controller" should {
-
-    "return 200 (OK)" when {
-
-      "display page method is invoked" in {
-
-        val result = controller.unauthorised()(getRequest())
+        val result = controller.displayPage()(getRequest())
 
         status(result) must be(OK)
       }

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/agents/AgentsControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/agents/AgentsControllerSpec.scala
@@ -68,13 +68,13 @@ class AgentsControllerSpec extends ControllerSpec {
         authorizedUser(agent, requiredPredicate = AffinityGroup.Agent)
 
         val result = controller.submit(
-          postRequest(Json.toJson(ClientIdentifier(identifier = "XMPPT1234567890")))
+          postRequest(Json.toJson(ClientIdentifier(identifier = "XMPPT0001234567")))
         )
 
         status(result) must be(SEE_OTHER)
         redirectLocation(result) must be(Some(homeRoutes.HomeController.displayPage().url))
 
-        await(result).newSession.flatMap(_.get("clientPPT")) must be(Some("XMPPT1234567890"))
+        await(result).newSession.flatMap(_.get("clientPPT")) must be(Some("XMPPT0001234567"))
       }
     }
   }

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/bta/BtaEntryPointControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/bta/BtaEntryPointControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.plasticpackagingtax.returns.controllers.bta
 
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/home/UnauthorisedControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/home/UnauthorisedControllerSpec.scala
@@ -21,6 +21,7 @@ import org.mockito.Mockito.{reset, when}
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
 import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.ControllerSpec
 import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthCheckActionImpl
 import uk.gov.hmrc.plasticpackagingtax.returns.views.html.home.unauthorised
@@ -51,13 +52,20 @@ class UnauthorisedControllerSpec extends ControllerSpec {
   "Unauthorised controller" should {
 
     "return 200 (OK)" when {
-
       "display page method is invoked" in {
-
         val result = controller.unauthorised()(getRequest())
 
         status(result) must be(OK)
       }
+
+      "enrolments page is invoked with by a signed in user" in {
+        authorizedUser(requiredPredicate = EmptyPredicate)
+
+        val result = controller.notEnrolled()(getRequest())
+
+        status(result) must be(OK)
+      }
     }
+
   }
 }

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/home/UnauthorisedControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/home/UnauthorisedControllerSpec.scala
@@ -22,15 +22,24 @@ import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.ControllerSpec
+import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
+import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthCheckActionImpl
 import uk.gov.hmrc.plasticpackagingtax.returns.views.html.home.unauthorised
-import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
 class UnauthorisedControllerSpec extends ControllerSpec {
 
   private val page = mock[unauthorised]
 
+  private val appConfig = mock[AppConfig]
+
+  val mockAuthCheckAction = new AuthCheckActionImpl(mockAuthConnector,
+                                                    appConfig,
+                                                    metricsMock,
+                                                    stubMessagesControllerComponents()
+  )
+
   val controller =
-    new UnauthorisedController(???, stubMessagesControllerComponents(), page)
+    new UnauthorisedController(mockAuthCheckAction, stubMessagesControllerComponents(), page)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/home/UnauthorisedControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/home/UnauthorisedControllerSpec.scala
@@ -30,7 +30,7 @@ class UnauthorisedControllerSpec extends ControllerSpec {
   private val page = mock[unauthorised]
 
   val controller =
-    new UnauthorisedController(stubMessagesControllerComponents(), page)
+    new UnauthorisedController(???, stubMessagesControllerComponents(), page)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -48,7 +48,7 @@ class UnauthorisedControllerSpec extends ControllerSpec {
 
       "display page method is invoked" in {
 
-        val result = controller.onPageLoad()(getRequest())
+        val result = controller.unauthorised()(getRequest())
 
         status(result) must be(OK)
       }

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/subscriptions/ViewSubscriptionControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/subscriptions/ViewSubscriptionControllerSpec.scala
@@ -150,7 +150,7 @@ class ViewSubscriptionControllerSpec extends ControllerSpec {
         val result = controller.displayPage()(authRequest(user = PptTestData.newUser("123", None)))
 
         status(result) mustBe SEE_OTHER
-        redirectLocation(result) mustBe Some(homeRoutes.UnauthorisedController.onPageLoad().url)
+        redirectLocation(result) mustBe Some(homeRoutes.UnauthorisedController.unauthorised().url)
       }
     }
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/subscriptions/ViewSubscriptionControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/subscriptions/ViewSubscriptionControllerSpec.scala
@@ -150,7 +150,7 @@ class ViewSubscriptionControllerSpec extends ControllerSpec {
         val result = controller.displayPage()(authRequest(user = PptTestData.newUser("123", None)))
 
         status(result) mustBe SEE_OTHER
-        redirectLocation(result) mustBe Some(homeRoutes.UnauthorisedController.unauthorised().url)
+        redirectLocation(result) mustBe Some(homeRoutes.UnauthorisedController.notEnrolled().url)
       }
     }
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/forms/ClientIdentifierSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/forms/ClientIdentifierSpec.scala
@@ -33,8 +33,8 @@ class ClientIdentifierSpec extends AnyWordSpec with Matchers {
 
     "return success" when {
 
-      "total is valid" in {
-        val input = Map(identifier -> "XMPPT0000000123")
+      "identifier is valid" in {
+        val input = Map(identifier -> "XAPPT0000000123")
 
         val form = ClientIdentifier.form().bind(input)
         form.errors.size mustBe 0

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/forms/ClientIdentifierSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/forms/ClientIdentifierSpec.scala
@@ -20,7 +20,12 @@ import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.data.FormError
 import uk.gov.hmrc.plasticpackagingtax.returns.forms.agents.ClientIdentifier
-import uk.gov.hmrc.plasticpackagingtax.returns.forms.agents.ClientIdentifier.{identifier, identifierEmptyError}
+import uk.gov.hmrc.plasticpackagingtax.returns.forms.agents.ClientIdentifier.{
+  formatError,
+  identifier,
+  identifierEmptyError,
+  lengthError
+}
 
 class ClientIdentifierSpec extends AnyWordSpec with Matchers {
 
@@ -29,7 +34,7 @@ class ClientIdentifierSpec extends AnyWordSpec with Matchers {
     "return success" when {
 
       "total is valid" in {
-        val input = Map(identifier -> "XMTP0000000001")
+        val input = Map(identifier -> "XMPPT0000000123")
 
         val form = ClientIdentifier.form().bind(input)
         form.errors.size mustBe 0
@@ -42,6 +47,42 @@ class ClientIdentifierSpec extends AnyWordSpec with Matchers {
           Map(identifier -> " ")
         val expectedErrors =
           Seq(FormError(identifier, identifierEmptyError))
+
+        testFailedValidationErrors(input, expectedErrors)
+      }
+
+      "provided with shorter than 15 character long input" in {
+        val input =
+          Map(identifier -> "XMPPT000000012")
+        val expectedErrors =
+          Seq(FormError(identifier, lengthError))
+
+        testFailedValidationErrors(input, expectedErrors)
+      }
+
+      "provided with longer than 15 character input" in {
+        val input =
+          Map(identifier -> "XMPPT00000001234")
+        val expectedErrors =
+          Seq(FormError(identifier, lengthError))
+
+        testFailedValidationErrors(input, expectedErrors)
+      }
+
+      "provided with an identifier which doesn't start with XMPTT" in {
+        val input =
+          Map(identifier -> "ABCDE0000000123")
+        val expectedErrors =
+          Seq(FormError(identifier, formatError))
+
+        testFailedValidationErrors(input, expectedErrors)
+      }
+
+      "provided with an identifier with none digits in the tail" in {
+        val input =
+          Map(identifier -> "XMPPT0000000ABC")
+        val expectedErrors =
+          Seq(FormError(identifier, formatError))
 
         testFailedValidationErrors(input, expectedErrors)
       }

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/forms/ClientIdentifierSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/forms/ClientIdentifierSpec.scala
@@ -62,14 +62,14 @@ class ClientIdentifierSpec extends AnyWordSpec with Matchers {
 
       "provided with longer than 15 character input" in {
         val input =
-          Map(identifier -> "XMPPT00000001234")
+          Map(identifier -> "XBPPT00000001234")
         val expectedErrors =
           Seq(FormError(identifier, lengthError))
 
         testFailedValidationErrors(input, expectedErrors)
       }
 
-      "provided with an identifier which doesn't start with XMPTT" in {
+      "provided with an identifier which doesn't start with correct prefix" in {
         val input =
           Map(identifier -> "ABCDE0000000123")
         val expectedErrors =
@@ -80,7 +80,7 @@ class ClientIdentifierSpec extends AnyWordSpec with Matchers {
 
       "provided with an identifier with none digits in the tail" in {
         val input =
-          Map(identifier -> "XMPPT0000000ABC")
+          Map(identifier -> "XZPPT0000000ABC")
         val expectedErrors =
           Seq(FormError(identifier, formatError))
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/forms/ClientIdentifierSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/forms/ClientIdentifierSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.returns.forms
+
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.data.FormError
+import uk.gov.hmrc.plasticpackagingtax.returns.forms.agents.ClientIdentifier
+import uk.gov.hmrc.plasticpackagingtax.returns.forms.agents.ClientIdentifier.{identifier, identifierEmptyError}
+
+class ClientIdentifierSpec extends AnyWordSpec with Matchers {
+
+  "Client identifier validation rules" should {
+
+    "return success" when {
+
+      "total is valid" in {
+        val input = Map(identifier -> "XMTP0000000001")
+
+        val form = ClientIdentifier.form().bind(input)
+        form.errors.size mustBe 0
+      }
+    }
+
+    "return errors" when {
+      "provided with empty data" in {
+        val input =
+          Map(identifier -> " ")
+        val expectedErrors =
+          Seq(FormError(identifier, identifierEmptyError))
+
+        testFailedValidationErrors(input, expectedErrors)
+      }
+    }
+  }
+
+  def testFailedValidationErrors(
+    input: Map[String, String],
+    expectedErrors: Seq[FormError]
+  ): Unit = {
+    val form = ClientIdentifier.form().bind(input)
+    expectedErrors.foreach(form.errors must contain(_))
+  }
+
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/agents/AgentsViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/agents/AgentsViewSpec.scala
@@ -16,24 +16,14 @@
 
 package uk.gov.hmrc.plasticpackagingtax.returns.views.agents
 
-import org.mockito.Mockito.when
 import org.scalatest.matchers.must.Matchers
 import play.api.test.FakeRequest
 import play.twirl.api.Html
 import uk.gov.hmrc.plasticpackagingtax.returns.base.PptTestData
 import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.UnitViewSpec
-import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
 import uk.gov.hmrc.plasticpackagingtax.returns.forms.agents.ClientIdentifier
-import uk.gov.hmrc.plasticpackagingtax.returns.models.financials.PPTFinancials
 import uk.gov.hmrc.plasticpackagingtax.returns.models.request.AuthenticatedRequest
-import uk.gov.hmrc.plasticpackagingtax.returns.models.subscription.subscriptionDisplay.SubscriptionDisplayResponse
-import uk.gov.hmrc.plasticpackagingtax.returns.views.home.SubscriptionTypes.{
-  Group,
-  Partnership,
-  SingleEntity
-}
 import uk.gov.hmrc.plasticpackagingtax.returns.views.html.agents.agents_page
-import uk.gov.hmrc.plasticpackagingtax.returns.views.html.home.home_page
 import uk.gov.hmrc.plasticpackagingtax.returns.views.tags.ViewTest
 import utils.FakeRequestCSRFSupport.CSRFFakeRequest
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/agents/AgentsViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/agents/AgentsViewSpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.returns.views.agents
+
+import org.mockito.Mockito.when
+import org.scalatest.matchers.must.Matchers
+import play.api.test.FakeRequest
+import play.twirl.api.Html
+import uk.gov.hmrc.plasticpackagingtax.returns.base.PptTestData
+import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.UnitViewSpec
+import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
+import uk.gov.hmrc.plasticpackagingtax.returns.forms.agents.ClientIdentifier
+import uk.gov.hmrc.plasticpackagingtax.returns.models.financials.PPTFinancials
+import uk.gov.hmrc.plasticpackagingtax.returns.models.request.AuthenticatedRequest
+import uk.gov.hmrc.plasticpackagingtax.returns.models.subscription.subscriptionDisplay.SubscriptionDisplayResponse
+import uk.gov.hmrc.plasticpackagingtax.returns.views.home.SubscriptionTypes.{
+  Group,
+  Partnership,
+  SingleEntity
+}
+import uk.gov.hmrc.plasticpackagingtax.returns.views.html.agents.agents_page
+import uk.gov.hmrc.plasticpackagingtax.returns.views.html.home.home_page
+import uk.gov.hmrc.plasticpackagingtax.returns.views.tags.ViewTest
+import utils.FakeRequestCSRFSupport.CSRFFakeRequest
+
+@ViewTest
+class AgentsViewSpec extends UnitViewSpec with Matchers {
+
+  private val agentsPage = instanceOf[agents_page]
+
+  val authenticatedRequest = new AuthenticatedRequest(FakeRequest().withCSRFToken,
+                                                      PptTestData.newUser(),
+                                                      Some("XMPPT0000000001")
+  )
+
+  private def createView(): Html =
+    agentsPage(ClientIdentifier.form())(authenticatedRequest, messages)
+
+  override def exerciseGeneratedRenderingMethods(): Unit = {
+    agentsPage.f(ClientIdentifier.form())(authenticatedRequest, messages)
+    agentsPage.render(ClientIdentifier.form(), authenticatedRequest, messages)
+  }
+
+  val view: Html = createView()
+
+  "Agents view" when {
+    "display sign out link" in {
+      displaySignOutLink(view)
+    }
+
+    "display title" in {
+      view.select("title").text() must include(messages("account.agents.selectClient.header"))
+    }
+  }
+
+}


### PR DESCRIPTION
### Description of Work carried through

Adjust AuthAction to allow agents to work with PPT accounts which they have been delegated access to.

TLDR - to auth as an Agent, you need to know the client's PPT identifier BEFORE calling auth,
This is different to the existing single user code with calls auth and then finds the PPT identifier in the auth response.

![Screenshot from 2022-03-18 09-29-45](https://user-images.githubusercontent.com/95688374/158977554-64c55540-6834-463d-91e8-1b82c760efe2.png)


## Prompt Agents for their client's PPT identifier

When auth'ing as an agent, the AuthAction might supply the PPT identifier of the account the agent is trying to access.

This has to be supplied as as a parameter to the auth call. 
This is different to the existing single user code which auths and then finds the PPT identifier from the enrolments in the auth response.

Add a new screen at `/agents` to prompt agents for the client identifier of their client.
This identifier is stashed on the MDTP session.
This screen is be protected with an agents only auth check.

If AuthAction is called and there is an agent supplied client identifier on the session then we should assume this request is from an agent and add the client identifer to the auth request.


## When to prompt for an agent supplied client id.

If a user is dropped out of AuthAction with `InsufficientEnrolments` they are redirected to a new not enroller end point at `/plastic-packaging-tax/account/not-enrolled`.


Users with insufficient enrolments are  we likely to be in one of these states:

- A single user who is not register for PPT.
They should be redirected to registration as per the existing behaviour

- An agent who has not supplied a client id
They should be redirected to `/agents` and prompted to supply one.

- An agent who has supplied an invalid client id or one which that have no delegated access too
The should be redirected back to `/agents` to supply a valid client id.

The auth client `InsufficiantEnrolments` does seem to supply any details about the authenticated users; so this new end point preforms a simple auth check with not enrolment predicate to determine who the user is.


## Reading the PPT identifier from auth enrolments does not work for agents

An agent's access to a client's enrolment is handled by a piece of auth code named `AgentDelegationPredicate`.
Importantly this code does not add the delegated enrolment to the auth enrolments response when an agent calls auth.

This means that any PPT code which is reading the PPT identifier from auth enrolments will not work with agents.
This is ok in the front end where we have access to the MTDP session and can see the user supplied client id.



#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed 
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
