### PR TITLE
PPTP-1721 : Create Return BTA Entry Point

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/bta/BtaEntryPointController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/bta/BtaEntryPointController.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.returns.controllers.bta
+
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.returns.controllers.returns.{routes => returnRoutes}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import javax.inject.{Inject, Singleton}
+
+@Singleton
+class BtaEntryPointController @Inject() (
+  authenticate: AuthAction,
+  mcc: MessagesControllerComponents
+) extends FrontendController(mcc) {
+
+  def startReturn(): Action[AnyContent] =
+    authenticate { implicit request =>
+      Redirect(returnRoutes.StartDateReturnController.displayPage())
+    }
+
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -6,4 +6,7 @@
 
 ->         /account                                     home.Routes
 
+# BTA entry points
+GET        /submit-return                               uk.gov.hmrc.plasticpackagingtax.returns.controllers.bta.BtaEntryPointController.startReturn()
+
 GET        /assets/*file                                controllers.Assets.versioned(path="/public", file: Asset)

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/bta/BtaEntryPointControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/bta/BtaEntryPointControllerSpec.scala
@@ -1,0 +1,33 @@
+package uk.gov.hmrc.plasticpackagingtax.returns.controllers.bta
+
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import play.api.test.Helpers.{await, redirectLocation}
+import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.ControllerSpec
+import uk.gov.hmrc.plasticpackagingtax.returns.controllers.returns.{routes => returnRoutes}
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
+
+class BtaEntryPointControllerSpec extends ControllerSpec {
+
+  private val mcc = stubMessagesControllerComponents()
+
+  private val controller = new BtaEntryPointController(authenticate = mockAuthAction, mcc = mcc)
+
+  "The BTA Entry Point Controller" should {
+    "redirect to the create tax return start page" when {
+      "user is authenticated" in {
+        authorizedUser()
+
+        redirectLocation(controller.startReturn()(getRequest())) mustBe Some(
+          returnRoutes.StartDateReturnController.displayPage().url
+        )
+      }
+    }
+    "throw an exception" when {
+      "user is unauthenticated" in {
+        unAuthorizedUser()
+
+        intercept[RuntimeException](await(controller.startReturn()(getRequest())))
+      }
+    }
+  }
+}


### PR DESCRIPTION
We support a fixed entry point from BTA. We issue a redirect to hit our current create return starting URL.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed 
 - [ ] Required Environment Config has been amended/added - N/A
 - [ ] Links to dependencies have been included (BE/FE work) - N/A
 - [ ] User Acceptance Tests (UAT) were run locally and have passed - N/A
 - [ ] No Accessibility errors/warnings reported by Wave - N/A
