### PR TITLE
PPTP-1843: Welsh translation toggle added to returns

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/config/AppConfig.scala
@@ -34,12 +34,20 @@ package uk.gov.hmrc.plasticpackagingtax.returns.config
 
 import play.api.Configuration
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
-
 import java.time.LocalDate
 import javax.inject.{Inject, Singleton}
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.{Cy, En, Language}
+import uk.gov.hmrc.plasticpackagingtax.returns.controllers.{routes => returnsRoutes}
 
 @Singleton
 class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesConfig) {
+
+  lazy val welshEnabled: Boolean = config.get[Boolean]("lang.welsh.enabled")
+
+  def languageLinks: Seq[(Language, String)] =
+    Seq((En, returnsRoutes.LanguageController.enGb().url),
+        (Cy, returnsRoutes.LanguageController.cyGb().url)
+    )
 
   lazy val assetsUrl: String = config.get[String]("assets.url")
 
@@ -60,7 +68,8 @@ class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesCo
   lazy val pptReturnsUrl: String           = s"$pptServiceHost/returns"
   lazy val pptReturnsSubmissionUrl: String = s"$pptServiceHost/returns-submission"
 
-  def pptReturnUrl(id: String): String           = s"$pptReturnsUrl/$id"
+  def pptReturnUrl(id: String): String = s"$pptReturnsUrl/$id"
+
   def pptReturnSubmissionUrl(id: String): String = s"$pptReturnsSubmissionUrl/$id"
 
   def pptSubscriptionUrl(pptReference: String): String =

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/LanguageController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/LanguageController.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.returns.controllers
+
+import play.api.i18n.Lang
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.{routes => returnsRoutes}
+import uk.gov.hmrc.play.language.LanguageUtils
+import javax.inject.Inject
+
+class LanguageController @Inject() (languageUtils: LanguageUtils, cc: MessagesControllerComponents)
+    extends uk.gov.hmrc.play.language.LanguageController(languageUtils, cc) {
+
+  def enGb(): Action[AnyContent] = switchToLanguage(language = "english")
+
+  def cyGb(): Action[AnyContent] = switchToLanguage(language = "cymraeg")
+
+  override def fallbackURL: String = returnsRoutes.HomeController.displayPage().url
+
+  override protected def languageMap: Map[String, Lang] =
+    Map("english" -> Lang("en"), "cymraeg" -> Lang("cy"))
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/main_template.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/main_template.scala.html
@@ -24,6 +24,9 @@
 @import uk.gov.hmrc.plasticpackagingtax.returns.config.TimeoutDialogConfig
 @import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcTrackingConsentSnippet
 @import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcStandardFooter
+@import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
+@import uk.gov.hmrc.hmrcfrontend.views.html.components.HmrcLanguageSelect
+@import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.LanguageSelect
 
 @this(
     govukHeader: GovukHeader,
@@ -37,6 +40,8 @@
     phaseBanner: phaseBanner,
     hmrcFooter: HmrcStandardFooter,
     govukFlexibleLayout: govukFlexibleLayout,
+    hmrcLanguageSelect: HmrcLanguageSelect,
+    appConfig: AppConfig
 )
 @(title: Title,
     backButton: Option[BackButton] = None,
@@ -79,6 +84,20 @@
 
 @beforeContentBlock = {
     @phaseBanner("alpha")
+    @{
+        def playLangToUiLanguage(l: Lang) = l.code.take(2) match {
+            case "cy" => Cy
+            case "en" => En
+            case _ => En
+        }
+
+        if(appConfig.welshEnabled) {
+            hmrcLanguageSelect(LanguageSelect(
+            playLangToUiLanguage(messages.lang),
+            appConfig.languageLinks: _*
+            ))
+        }
+    }
 }
 
 @content = {

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -7,3 +7,7 @@
 ->         /account                                     home.Routes
 
 GET        /assets/*file                                controllers.Assets.versioned(path="/public", file: Asset)
+
+#Welsh Translation
+GET        /lang/enGb                                   uk.gov.hmrc.plasticpackagingtax.returns.controllers.LanguageController.enGb()
+GET        /lang/cyGb                                   uk.gov.hmrc.plasticpackagingtax.returns.controllers.LanguageController.cyGb()

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -42,6 +42,10 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 # Provides authentication integration with gg
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 
+play.i18n.langs = ["en", "cy"]
+
+lang.welsh.enabled = true
+
 # Custom error handler
 play.http.errorHandler = "uk.gov.hmrc.plasticpackagingtax.returns.config.ErrorHandler"
 

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -1,0 +1,1 @@
+#page left deliberately blank for Welsh translations

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/LanguageControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/LanguageControllerSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.returns.controllers
+
+import play.api.test.Helpers._
+import play.api.test.{FakeRequest, Injecting}
+import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.ControllerSpec
+import uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.{routes => returnsRoutes}
+
+class LanguageControllerSpec extends ControllerSpec with Injecting {
+
+  lazy val controller = inject[LanguageController]
+  val request         = FakeRequest()
+
+  "Calling LanguageController.enGb" should {
+    "change the language to English and return 303" in {
+      val result = controller.enGb()(request)
+      cookies(result).get("PLAY_LANG").get.value shouldBe "en"
+      status(result) shouldBe SEE_OTHER
+    }
+  }
+
+  "Calling LanguageController.cyGb" should {
+    "change the language to Welsh and return 303" in {
+      val result = controller.cyGb()(request)
+      cookies(result).get("PLAY_LANG").get.value shouldBe "cy"
+      status(result) shouldBe SEE_OTHER
+    }
+  }
+
+  "changeLang" should {
+    "redirect" when {
+      "redirect URI contains the path" in {
+        val request = FakeRequest()
+        val result  = controller.cyGb()(request)
+        cookies(result).get("PLAY_LANG").get.value shouldBe "cy"
+        status(result) shouldBe SEE_OTHER
+        redirectLocation(result).get shouldBe returnsRoutes.HomeController.displayPage().url
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/StartPageViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/StartPageViewSpec.scala
@@ -115,7 +115,7 @@ class StartPageViewSpec extends UnitViewSpec with Matchers {
                  messages("returns.startPage.whatIsLiable.body.3.link")
         )
       )
-      view.getElementsByClass("govuk-link").get(1) must haveHref(
+      view.getElementsByClass("govuk-link").get(2) must haveHref(
         "https://www.gov.uk/government/publications/introduction-of-plastic-packaging-tax/plastic-packaging-tax"
       )
     }


### PR DESCRIPTION
### Description of Work carried through

- page language switching added
- feature has as toggle to disable language options until translations are complete

#### Check list 
 - [ x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x ] `sbt scalafmt test:scalafmt` was executed 
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [ x] No Accessibility errors/warnings reported by Wave
