### PR TITLE
PPTP-1851 Returns sends signed in user for uplift if they do not have strong credentials

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/config/AppConfig.scala
@@ -61,6 +61,7 @@ class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesCo
 
   lazy val loginUrl         = config.get[String]("urls.login")
   lazy val loginContinueUrl = config.get[String]("urls.loginContinue")
+  lazy val mfaUpliftUrl     = config.get[String]("urls.mfaUplift")
 
   lazy val pptServiceHost: String =
     servicesConfig.baseUrl("plastic-packaging-tax-returns")

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
@@ -22,14 +22,12 @@ import play.api.Logger
 import play.api.mvc.Results.Redirect
 import play.api.mvc._
 import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.authorise.Predicate
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
 import uk.gov.hmrc.auth.core.retrieve.~
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
-import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthAction.{
-  pptEnrolmentIdentifierName,
-  pptEnrolmentKey
-}
+import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthAction.{pptEnrolmentIdentifierName, pptEnrolmentKey}
 import uk.gov.hmrc.plasticpackagingtax.returns.controllers.agents.{routes => agentRoutes}
 import uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.{routes => homeRoutes}
 import uk.gov.hmrc.plasticpackagingtax.returns.models.SignedInUser
@@ -182,7 +180,7 @@ class AuthActionImpl @Inject() (
       .flatMap(_.identifiers)
       .find(_.key == identifier)
 
-  private def authPredicate(selectedClientIdentifier: Option[String] = None) =
+  private def authPredicate(selectedClientIdentifier: Option[String] = None): Predicate =
     selectedClientIdentifier.map { clientIdentifier =>
       // If this request is decorated with a selected client identifier this indicates
       // an agent at work; we need to request the delegated authority
@@ -191,7 +189,7 @@ class AuthActionImpl @Inject() (
       ).withDelegatedAuthRule("ppt-auth")
     }.getOrElse {
       Enrolment(pptEnrolmentKey)
-    }
+    }.and(CredentialStrength(CredentialStrength.strong))
 
 }
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
@@ -23,7 +23,6 @@ import play.api.mvc.Results.Redirect
 import play.api.mvc._
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.authorise.Predicate
-import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
 import uk.gov.hmrc.auth.core.retrieve.~
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
@@ -42,7 +41,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class AuthActionImpl @Inject() (
   override val authConnector: AuthConnector,
   pptReferenceAllowedList: PptReferenceAllowedList,
-  appConfig: AppConfig,
+  override val appConfig: AppConfig,
   metrics: Metrics,
   mcc: MessagesControllerComponents
 ) extends AuthAction with AuthorisedFunctions with CommonAuth {
@@ -127,6 +126,9 @@ class AuthActionImpl @Inject() (
       } recover {
       case _: NoActiveSession =>
         Results.Redirect(appConfig.loginUrl, Map("continue" -> Seq(appConfig.loginContinueUrl)))
+
+      case _: IncorrectCredentialStrength =>
+        upliftCredentialStrength
 
       case _: InsufficientEnrolments =>
         // Redirect to the non enrolled page; this is authed but doesn't need enrolments.

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
@@ -27,7 +27,10 @@ import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
 import uk.gov.hmrc.auth.core.retrieve.~
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
-import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthAction.{pptEnrolmentIdentifierName, pptEnrolmentKey}
+import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthAction.{
+  pptEnrolmentIdentifierName,
+  pptEnrolmentKey
+}
 import uk.gov.hmrc.plasticpackagingtax.returns.controllers.agents.{routes => agentRoutes}
 import uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.{routes => homeRoutes}
 import uk.gov.hmrc.plasticpackagingtax.returns.models.SignedInUser

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
@@ -45,17 +45,12 @@ class AuthActionImpl @Inject() (
   appConfig: AppConfig,
   metrics: Metrics,
   mcc: MessagesControllerComponents
-) extends AuthAction with AuthorisedFunctions {
+) extends AuthAction with AuthorisedFunctions with CommonAuth {
 
   implicit override val executionContext: ExecutionContext = mcc.executionContext
   override val parser: BodyParser[AnyContent]              = mcc.parsers.defaultBodyParser
   private val logger                                       = Logger(this.getClass)
   private val authTimer                                    = metrics.defaultRegistry.timer("ppt.returns.upstream.auth.timer")
-
-  private val authData =
-    credentials and name and email and externalId and internalId and affinityGroup and allEnrolments and
-      agentCode and confidenceLevel and nino and saUtr and dateOfBirth and agentInformation and groupIdentifier and
-      credentialRole and mdtpInformation and itmpName and itmpDateOfBirth and itmpAddress and credentialStrength and loginTimes
 
   override def invokeBlock[A](
     request: Request[A],

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAgentAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAgentAction.scala
@@ -36,16 +36,11 @@ class AuthAgentActionImpl @Inject() (
   appConfig: AppConfig,
   metrics: Metrics,
   mcc: MessagesControllerComponents
-) extends AuthAgentAction with AuthorisedFunctions {
+) extends AuthAgentAction with AuthorisedFunctions with CommonAuth {
 
   implicit override val executionContext: ExecutionContext = mcc.executionContext
   override val parser: BodyParser[AnyContent]              = mcc.parsers.defaultBodyParser
   private val authTimer                                    = metrics.defaultRegistry.timer("ppt.returns.upstream.auth.timer")
-
-  private val authData =
-    credentials and name and email and externalId and internalId and affinityGroup and allEnrolments and
-      agentCode and confidenceLevel and nino and saUtr and dateOfBirth and agentInformation and groupIdentifier and
-      credentialRole and mdtpInformation and itmpName and itmpDateOfBirth and itmpAddress and credentialStrength and loginTimes
 
   override def invokeBlock[A](
     request: Request[A],

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAgentAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAgentAction.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions
 
 import com.google.inject.{ImplementedBy, Inject}
 import com.kenshoo.play.metrics.Metrics
-import play.api.Logger
 import play.api.mvc._
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
@@ -41,7 +40,6 @@ class AuthAgentActionImpl @Inject() (
 
   implicit override val executionContext: ExecutionContext = mcc.executionContext
   override val parser: BodyParser[AnyContent]              = mcc.parsers.defaultBodyParser
-  private val logger                                       = Logger(this.getClass)
   private val authTimer                                    = metrics.defaultRegistry.timer("ppt.returns.upstream.auth.timer")
 
   private val authData =
@@ -58,7 +56,7 @@ class AuthAgentActionImpl @Inject() (
 
     val authorisation = authTimer.time()
 
-    authorised(AffinityGroup.Agent)
+    authorised(AffinityGroup.Agent.and(CredentialStrength(CredentialStrength.strong)))
       .retrieve(authData) {
         case credentials ~ name ~ email ~ externalId ~ internalId ~ affinityGroup ~ allEnrolments ~ agentCode ~
             confidenceLevel ~ authNino ~ saUtr ~ dateOfBirth ~ agentInformation ~ groupIdentifier ~

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAgentAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAgentAction.scala
@@ -20,7 +20,6 @@ import com.google.inject.{ImplementedBy, Inject}
 import com.kenshoo.play.metrics.Metrics
 import play.api.mvc._
 import uk.gov.hmrc.auth.core._
-import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
 import uk.gov.hmrc.auth.core.retrieve.~
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
@@ -33,7 +32,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class AuthAgentActionImpl @Inject() (
   override val authConnector: AuthConnector,
-  appConfig: AppConfig,
+  override val appConfig: AppConfig,
   metrics: Metrics,
   mcc: MessagesControllerComponents
 ) extends AuthAgentAction with AuthorisedFunctions with CommonAuth {
@@ -84,6 +83,9 @@ class AuthAgentActionImpl @Inject() (
       } recover {
       case _: NoActiveSession =>
         Results.Redirect(appConfig.loginUrl, Map("continue" -> Seq(appConfig.loginContinueUrl)))
+
+      case _: IncorrectCredentialStrength =>
+        upliftCredentialStrength
 
       case _: AuthorisationException =>
         Results.Redirect(homeRoutes.UnauthorisedController.unauthorised())

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthCheckAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthCheckAction.scala
@@ -38,17 +38,12 @@ class AuthCheckActionImpl @Inject() (
   appConfig: AppConfig,
   metrics: Metrics,
   mcc: MessagesControllerComponents
-) extends AuthCheckAction with AuthorisedFunctions {
+) extends AuthCheckAction with AuthorisedFunctions with CommonAuth {
 
   implicit override val executionContext: ExecutionContext = mcc.executionContext
   override val parser: BodyParser[AnyContent]              = mcc.parsers.defaultBodyParser
   private val logger                                       = Logger(this.getClass)
   private val authTimer                                    = metrics.defaultRegistry.timer("ppt.returns.upstream.auth.timer")
-
-  private val authData =
-    credentials and name and email and externalId and internalId and affinityGroup and allEnrolments and
-      agentCode and confidenceLevel and nino and saUtr and dateOfBirth and agentInformation and groupIdentifier and
-      credentialRole and mdtpInformation and itmpName and itmpDateOfBirth and itmpAddress and credentialStrength and loginTimes
 
   override def invokeBlock[A](
     request: Request[A],

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthCheckAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthCheckAction.scala
@@ -59,7 +59,7 @@ class AuthCheckActionImpl @Inject() (
 
     val authorisation = authTimer.time()
 
-    authorised(EmptyPredicate.and(CredentialStrength(CredentialStrength.strong)))
+    authorised(CredentialStrength(CredentialStrength.strong))
       .retrieve(authData) {
         case credentials ~ name ~ email ~ externalId ~ internalId ~ affinityGroup ~ allEnrolments ~ agentCode ~
             confidenceLevel ~ authNino ~ saUtr ~ dateOfBirth ~ agentInformation ~ groupIdentifier ~

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthCheckAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthCheckAction.scala
@@ -59,7 +59,7 @@ class AuthCheckActionImpl @Inject() (
 
     val authorisation = authTimer.time()
 
-    authorised(EmptyPredicate)
+    authorised(EmptyPredicate.and(CredentialStrength(CredentialStrength.strong)))
       .retrieve(authData) {
         case credentials ~ name ~ email ~ externalId ~ internalId ~ affinityGroup ~ allEnrolments ~ agentCode ~
             confidenceLevel ~ authNino ~ saUtr ~ dateOfBirth ~ agentInformation ~ groupIdentifier ~

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthCheckAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthCheckAction.scala
@@ -21,8 +21,6 @@ import com.kenshoo.play.metrics.Metrics
 import play.api.Logger
 import play.api.mvc._
 import uk.gov.hmrc.auth.core._
-import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
-import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
 import uk.gov.hmrc.auth.core.retrieve.~
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
@@ -35,7 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class AuthCheckActionImpl @Inject() (
   override val authConnector: AuthConnector,
-  appConfig: AppConfig,
+  override val appConfig: AppConfig,
   metrics: Metrics,
   mcc: MessagesControllerComponents
 ) extends AuthCheckAction with AuthorisedFunctions with CommonAuth {
@@ -90,7 +88,10 @@ class AuthCheckActionImpl @Inject() (
 
       } recover {
       case _: NoActiveSession =>
-        Results.Redirect(appConfig.loginUrl, Map("continue" -> Seq(appConfig.loginContinueUrl)))
+        redirectToSignin
+
+      case _: IncorrectCredentialStrength =>
+        upliftCredentialStrength
 
       case _: AuthorisationException =>
         Results.Redirect(homeRoutes.UnauthorisedController.unauthorised())

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/CommonAuth.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/CommonAuth.scala
@@ -16,14 +16,29 @@
 
 package uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions
 
+import play.api.mvc.Results.Redirect
+import play.api.mvc.{Result, Results}
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.credentials
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
+import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
 
 trait CommonAuth {
+
+  def appConfig: AppConfig
 
   protected val authData =
     credentials and name and email and externalId and internalId and affinityGroup and allEnrolments and
       agentCode and confidenceLevel and nino and saUtr and dateOfBirth and agentInformation and groupIdentifier and
       credentialRole and mdtpInformation and itmpName and itmpDateOfBirth and itmpAddress and credentialStrength and loginTimes
+
+  protected def redirectToSignin[A]: Result =
+    Results.Redirect(appConfig.loginUrl, Map("continue" -> Seq(appConfig.loginContinueUrl)))
+
+  protected def upliftCredentialStrength[A]: Result =
+    Results.Redirect(appConfig.mfaUpliftUrl,
+                     Map("origin"      -> Seq(appConfig.serviceIdentifier),
+                         "continueUrl" -> Seq(appConfig.loginContinueUrl)
+                     )
+    )
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/CommonAuth.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/CommonAuth.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions
+
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.credentials
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
+
+trait CommonAuth {
+
+  protected val authData =
+    credentials and name and email and externalId and internalId and affinityGroup and allEnrolments and
+      agentCode and confidenceLevel and nino and saUtr and dateOfBirth and agentInformation and groupIdentifier and
+      credentialRole and mdtpInformation and itmpName and itmpDateOfBirth and itmpAddress and credentialStrength and loginTimes
+
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -135,6 +135,7 @@ urls {
   exitSurvey = "http://localhost:9514/feedback/plastic-packaging-tax-registration"
   login = "http://localhost:9949/auth-login-stub/gg-sign-in"
   loginContinue = "http://localhost:8505/plastic-packaging-tax/account"
+  mfaUplift = "http://localhost:9553/bas-gateway/uplift-mfa"
   feedback = {
     authenticatedLink = "http://localhost:9250/contact/beta-feedback"
     unauthenticatedLink = "http://localhost:9250/contact/beta-feedback-unauthenticated"

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/base/MockAuthAction.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/base/MockAuthAction.scala
@@ -76,7 +76,8 @@ trait MockAuthAction extends MockitoSugar with MetricsMocks {
   val nrsLoginTimes               = LoginTimes(currentLoginTime, Some(previousLoginTime))
 
   // format: off
-  def authorizedUser(user: SignedInUser = exampleUser, requiredPredicate: Predicate = Enrolment("HMRC-PPT-ORG")): Unit = {
+  def authorizedUser(user: SignedInUser = exampleUser, requiredPredicate: Predicate = Enrolment("HMRC-PPT-ORG").
+    and(CredentialStrength(CredentialStrength.strong))): Unit = {
     when(
       mockAuthConnector.authorise(
         ArgumentMatchers.eq(requiredPredicate),

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthActionSpec.scala
@@ -20,7 +20,13 @@ import org.mockito.Mockito.when
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import play.api.mvc.{Headers, Results}
 import play.api.test.Helpers._
-import uk.gov.hmrc.auth.core.{CredentialStrength, Enrolment, InternalError, MissingBearerToken}
+import uk.gov.hmrc.auth.core.{
+  CredentialStrength,
+  Enrolment,
+  IncorrectCredentialStrength,
+  InternalError,
+  MissingBearerToken
+}
 import uk.gov.hmrc.plasticpackagingtax.returns.base.PptTestData.{
   newEnrolment,
   newEnrolments,
@@ -156,7 +162,7 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
       authorizedUser(user)
 
       await(createAuthAction().invokeBlock(authRequest(Headers(), user), okResponseGenerator))
-      metricsMock.defaultRegistry.timer("ppt.returns.upstream.auth.timer").getCount should be > 1L
+      metricsMock.defaultRegistry.timer("ppt.returns.upstream.auth.timer").getCount should be > 0L
     }
 
     "process request when enrolment id is present and allowed" in {
@@ -198,6 +204,22 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
         )
 
       redirectLocation(result) mustBe Some("login-url?continue=login-continue-url")
+    }
+
+    "redirect the user to MFA Uplift page if the user has incorrect credential strength " in {
+      when(appConfig.mfaUpliftUrl).thenReturn("mfa-uplift-url")
+      when(appConfig.loginContinueUrl).thenReturn("login-continue-url")
+      when(appConfig.serviceIdentifier).thenReturn("PPT")
+
+      whenAuthFailsWith(IncorrectCredentialStrength())
+      val result =
+        createAuthAction().invokeBlock(authRequest(Headers(), PptTestData.newUser()),
+                                       okResponseGenerator
+        )
+
+      redirectLocation(result) mustBe Some(
+        "mfa-uplift-url?origin=PPT&continueUrl=login-continue-url"
+      )
     }
 
     "redirect to unauthorised page when authorisation fails for a reason unrelated to insufficient enrolments" in {

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthActionSpec.scala
@@ -20,7 +20,7 @@ import org.mockito.Mockito.when
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import play.api.mvc.{Headers, Results}
 import play.api.test.Helpers._
-import uk.gov.hmrc.auth.core.{Enrolment, InternalError, MissingBearerToken}
+import uk.gov.hmrc.auth.core.{CredentialStrength, Enrolment, InternalError, MissingBearerToken}
 import uk.gov.hmrc.plasticpackagingtax.returns.base.PptTestData.{
   newEnrolment,
   newEnrolments,
@@ -90,7 +90,7 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
       val agentDelegatedAuthPredicate =
         Enrolment("HMRC-PPT-ORG").withIdentifier(pptEnrolmentIdentifierName,
                                                  "XMPPT0000000123"
-        ).withDelegatedAuthRule("ppt-auth")
+        ).withDelegatedAuthRule("ppt-auth").and(CredentialStrength(CredentialStrength.strong))
       authorizedUser(agent, requiredPredicate = agentDelegatedAuthPredicate)
       await(
         createAuthAction().invokeBlock(authRequest(Headers(), agent, Some("XMPPT0000000123")),

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAgentSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAgentSpec.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions
+
+import org.mockito.Mockito.when
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import play.api.mvc.{Headers, Results}
+import play.api.test.Helpers._
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.plasticpackagingtax.returns.base.PptTestData.pptEnrolment
+import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.ControllerSpec
+import uk.gov.hmrc.plasticpackagingtax.returns.base.{MetricsMocks, PptTestData}
+import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
+import uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.{routes => homeRoutes}
+import uk.gov.hmrc.plasticpackagingtax.returns.models.request.AuthenticatedRequest
+
+import scala.concurrent.Future
+
+class AuthAgentSpec extends ControllerSpec with MetricsMocks {
+
+  private val appConfig = mock[AppConfig]
+
+  private def createAuthAction(): AuthAgentAction =
+    new AuthAgentActionImpl(mockAuthConnector,
+                            appConfig,
+                            metricsMock,
+                            stubMessagesControllerComponents()
+    )
+
+  private val okResponseGenerator = (_: AuthenticatedRequest[_]) => Future(Results.Ok)
+
+  "Auth Agent Action" should {
+
+    "time calls to authorisation" in {
+      val user = PptTestData.newAgent("123")
+      authorizedUser(user,
+                     requiredPredicate =
+                       AffinityGroup.Agent.and(CredentialStrength(CredentialStrength.strong))
+      )
+
+      val result =
+        await(createAuthAction().invokeBlock(authRequest(Headers(), user), okResponseGenerator))
+      metricsMock.defaultRegistry.timer("ppt.returns.upstream.auth.timer").getCount should be > 0L
+    }
+
+    "process request when signed in user has agent affinity" in {
+      val user = PptTestData.newAgent("123")
+      authorizedUser(user,
+                     requiredPredicate =
+                       AffinityGroup.Agent.and(CredentialStrength(CredentialStrength.strong))
+      )
+
+      await(
+        createAuthAction().invokeBlock(authRequest(Headers(), user), okResponseGenerator)
+      ) mustBe Results.Ok
+    }
+
+    "redirect when user not logged in" in {
+
+      when(appConfig.loginUrl).thenReturn("login-url")
+      when(appConfig.loginContinueUrl).thenReturn("login-continue-url")
+
+      whenAuthFailsWith(MissingBearerToken())
+
+      val result =
+        createAuthAction().invokeBlock(authRequest(Headers(), PptTestData.newUser()),
+                                       okResponseGenerator
+        )
+
+      redirectLocation(result) mustBe Some("login-url?continue=login-continue-url")
+    }
+
+    "redirect the user to MFA Uplift page if the user has incorrect credential strength " in {
+      when(appConfig.mfaUpliftUrl).thenReturn("mfa-uplift-url")
+      when(appConfig.loginContinueUrl).thenReturn("login-continue-url")
+      when(appConfig.serviceIdentifier).thenReturn("PPT")
+
+      whenAuthFailsWith(IncorrectCredentialStrength())
+      val result =
+        createAuthAction().invokeBlock(authRequest(Headers(), PptTestData.newUser()),
+                                       okResponseGenerator
+        )
+
+      redirectLocation(result) mustBe Some(
+        "mfa-uplift-url?origin=PPT&continueUrl=login-continue-url"
+      )
+    }
+
+    "redirect to unauthorised page when authorisation fails" in {
+      whenAuthFailsWith(InternalError("Some unexpected auth error"))
+
+      val result =
+        createAuthAction().invokeBlock(authRequest(Headers(), PptTestData.newUser()),
+                                       okResponseGenerator
+        )
+
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(homeRoutes.UnauthorisedController.unauthorised().url)
+    }
+  }
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthCheckSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthCheckSpec.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions
+
+import org.mockito.Mockito.when
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import play.api.mvc.{Headers, Results}
+import play.api.test.Helpers._
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.ControllerSpec
+import uk.gov.hmrc.plasticpackagingtax.returns.base.{MetricsMocks, PptTestData}
+import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
+import uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.{routes => homeRoutes}
+import uk.gov.hmrc.plasticpackagingtax.returns.models.request.AuthenticatedRequest
+
+import scala.concurrent.Future
+
+class AuthCheckSpec extends ControllerSpec with MetricsMocks {
+
+  private val appConfig = mock[AppConfig]
+
+  private def createAuthAction(): AuthAgentAction =
+    new AuthAgentActionImpl(mockAuthConnector,
+                            appConfig,
+                            metricsMock,
+                            stubMessagesControllerComponents()
+    )
+
+  private val okResponseGenerator = (_: AuthenticatedRequest[_]) => Future(Results.Ok)
+
+  "Auth Check Action" should {
+
+    "time calls to authorisation" in {
+      val user = PptTestData.newUser()
+      authorizedUser(user,
+                     requiredPredicate =
+                       AffinityGroup.Agent.and(CredentialStrength(CredentialStrength.strong))
+      )
+
+      val result =
+        await(createAuthAction().invokeBlock(authRequest(Headers(), user), okResponseGenerator))
+      metricsMock.defaultRegistry.timer("ppt.returns.upstream.auth.timer").getCount should be > 0L
+    }
+
+    "process request when signed in user" in {
+      val user = PptTestData.newUser()
+      authorizedUser(user,
+                     requiredPredicate =
+                       AffinityGroup.Agent.and(CredentialStrength(CredentialStrength.strong))
+      )
+
+      await(
+        createAuthAction().invokeBlock(authRequest(Headers(), user), okResponseGenerator)
+      ) mustBe Results.Ok
+    }
+
+    "redirect when user not logged in" in {
+      when(appConfig.loginUrl).thenReturn("login-url")
+      when(appConfig.loginContinueUrl).thenReturn("login-continue-url")
+
+      whenAuthFailsWith(MissingBearerToken())
+
+      val result =
+        createAuthAction().invokeBlock(authRequest(Headers(), PptTestData.newUser()),
+                                       okResponseGenerator
+        )
+
+      redirectLocation(result) mustBe Some("login-url?continue=login-continue-url")
+    }
+
+    "redirect the user to MFA Uplift page if the user has incorrect credential strength " in {
+      when(appConfig.mfaUpliftUrl).thenReturn("mfa-uplift-url")
+      when(appConfig.loginContinueUrl).thenReturn("login-continue-url")
+      when(appConfig.serviceIdentifier).thenReturn("PPT")
+
+      whenAuthFailsWith(IncorrectCredentialStrength())
+      val result =
+        createAuthAction().invokeBlock(authRequest(Headers(), PptTestData.newUser()),
+                                       okResponseGenerator
+        )
+
+      redirectLocation(result) mustBe Some(
+        "mfa-uplift-url?origin=PPT&continueUrl=login-continue-url"
+      )
+    }
+
+    "redirect to unauthorised page when authorisation fails" in {
+      whenAuthFailsWith(InternalError("Some unexpected auth error"))
+
+      val result =
+        createAuthAction().invokeBlock(authRequest(Headers(), PptTestData.newUser()),
+                                       okResponseGenerator
+        )
+
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(homeRoutes.UnauthorisedController.unauthorised().url)
+    }
+  }
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/agents/AgentsControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/agents/AgentsControllerSpec.scala
@@ -23,7 +23,7 @@ import play.api.http.Status.{OK, SEE_OTHER}
 import play.api.libs.json.Json
 import play.api.test.Helpers.{await, redirectLocation, status, stubMessagesControllerComponents}
 import play.twirl.api.HtmlFormat
-import uk.gov.hmrc.auth.core.AffinityGroup
+import uk.gov.hmrc.auth.core.{AffinityGroup, CredentialStrength}
 import uk.gov.hmrc.plasticpackagingtax.returns.base.PptTestData
 import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.ControllerSpec
 import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthAgentActionImpl
@@ -54,7 +54,10 @@ class AgentsControllerSpec extends ControllerSpec {
     "display client identifier page" when {
       "agent is authorised and display select client page is requested" in {
         val agent = PptTestData.newAgent("456")
-        authorizedUser(agent, requiredPredicate = AffinityGroup.Agent)
+        authorizedUser(agent,
+                       requiredPredicate =
+                         AffinityGroup.Agent.and(CredentialStrength(CredentialStrength.strong))
+        )
 
         val result = controller.displayPage()(getRequest())
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/home/UnauthorisedControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/home/UnauthorisedControllerSpec.scala
@@ -21,7 +21,7 @@ import org.mockito.Mockito.{reset, when}
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
-import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
+import uk.gov.hmrc.auth.core.CredentialStrength
 import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.ControllerSpec
 import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthCheckActionImpl
 import uk.gov.hmrc.plasticpackagingtax.returns.views.html.home.unauthorised
@@ -59,7 +59,7 @@ class UnauthorisedControllerSpec extends ControllerSpec {
       }
 
       "enrolments page is invoked with by a signed in user" in {
-        authorizedUser(requiredPredicate = EmptyPredicate)
+        authorizedUser(requiredPredicate = CredentialStrength(CredentialStrength.strong))
 
         val result = controller.notEnrolled()(getRequest())
 


### PR DESCRIPTION
### Description of Work carried through

Returns front end requires strong credentials for consistency with Registration.

1 failing acceptance test looks unrelated.


#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed 
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
