### PR TITLE
PPTP-1853 Warn agents when the PPT identifier they have supplied fails auth

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
@@ -58,7 +58,7 @@ class AuthActionImpl @Inject() (
     implicit val hc: HeaderCarrier =
       HeaderCarrierConverter.fromRequestAndSession(request, request.session)
 
-    // In theory this could be deduplicated with SelectedClientIdentifier by the generic makes it too differcult
+    // In theory this could be deduplicated with SelectedClientIdentifier by the generic makes it too difficult
     def getSelectedClientIdentifier() = request.session.get("clientPPT")
 
     val authorisation            = authTimer.time()

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -54,6 +54,7 @@ account.agents.selectClient.hint.body=This is the 15 character reference they re
 agents.client.identifier.empty.error=Client PPT reference must be supplied and non blank
 agents.client.identifier.length.error=Client PPT reference should be 15 characters in length
 agents.client.identifier.format.error=A client PPT reference should be 15 characters long and start with X
+agents.client.identifier.auth.error=The PPT reference you have supplied is either incorrect or the client has not delegated you access. Please contact your client to confirm that this PPT reference is correct.
 
 account.homePage.title = Your Plastic Packaging Tax account
 account.homePage.registrationNumber = PPT registration number: {0}

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/agents/AgentsControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/agents/AgentsControllerSpec.scala
@@ -19,8 +19,9 @@ package uk.gov.hmrc.plasticpackagingtax.returns.controllers.agents
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
-import play.api.http.Status.{OK, SEE_OTHER}
+import play.api.http.Status.{FORBIDDEN, OK, SEE_OTHER}
 import play.api.libs.json.Json
+import play.api.test.FakeRequest
 import play.api.test.Helpers.{await, redirectLocation, status, stubMessagesControllerComponents}
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.auth.core.{AffinityGroup, CredentialStrength}
@@ -78,6 +79,19 @@ class AgentsControllerSpec extends ControllerSpec {
         redirectLocation(result) must be(Some(homeRoutes.HomeController.displayPage().url))
 
         await(result).newSession.flatMap(_.get("clientPPT")) must be(Some("XMPPT0001234567"))
+      }
+    }
+
+    "show error" when {
+      "not enrolled has flashed an auth error" in {
+        val agent = PptTestData.newAgent("456")
+        authorizedUser(agent, requiredPredicate = AffinityGroup.Agent)
+        val requestWithAuthErrorFlash =
+          FakeRequest().withFlash(("clientPPTFailed", "true"))
+
+        val result = controller.displayPage()(requestWithAuthErrorFlash)
+
+        status(result) must be(FORBIDDEN)
       }
     }
   }

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/home/UnauthorisedControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/home/UnauthorisedControllerSpec.scala
@@ -19,12 +19,15 @@ package uk.gov.hmrc.plasticpackagingtax.returns.controllers.home
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, when}
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.auth.core.CredentialStrength
+import uk.gov.hmrc.plasticpackagingtax.returns.base.PptTestData
 import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.ControllerSpec
 import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthCheckActionImpl
 import uk.gov.hmrc.plasticpackagingtax.returns.views.html.home.unauthorised
+import uk.gov.hmrc.plasticpackagingtax.returns.controllers.agents.{routes => agentRoutes}
 
 class UnauthorisedControllerSpec extends ControllerSpec {
 
@@ -51,7 +54,7 @@ class UnauthorisedControllerSpec extends ControllerSpec {
 
   "Unauthorised controller" should {
 
-    "return 200 (OK)" when {
+    "show the unauthorised page" when {
       "display page method is invoked" in {
         val result = controller.unauthorised()(getRequest())
 
@@ -67,5 +70,34 @@ class UnauthorisedControllerSpec extends ControllerSpec {
       }
     }
 
+    "redirect to the agents landing page" when {
+      "an agent lands on the not enrolled page after attempt to auth" in {
+        val agent = PptTestData.newAgent("456")
+        authorizedUser(user = agent,
+                       requiredPredicate = CredentialStrength(CredentialStrength.strong)
+        )
+
+        val result = controller.notEnrolled()(getRequest())
+
+        status(result) must be(SEE_OTHER)
+        redirectLocation(result) mustBe Some(agentRoutes.AgentsController.displayPage().url)
+      }
+
+      "flashing a client PPT identifier not authorised is an agent set an identifier and still ended up on the not enrolled page" in {
+        // This is a strong indication that the client PPT identifier is either unregistered or the client has not setup a delegated authorisation for this agent
+        val agent = PptTestData.newAgent("456")
+        authorizedUser(user = agent,
+                       requiredPredicate = CredentialStrength(CredentialStrength.strong)
+        )
+
+        val requestWithClientIdentifierSet =
+          FakeRequest().withSession(("clientPPT", "XMPTT0000000001"))
+        val result = controller.notEnrolled()(requestWithClientIdentifierSet)
+
+        status(result) must be(SEE_OTHER)
+        redirectLocation(result) mustBe Some(agentRoutes.AgentsController.displayPage().url)
+        flash(result).get("clientPPTFailed") mustBe Some("true")
+      }
+    }
   }
 }


### PR DESCRIPTION
### Description of Work carried through

Not enrolled landing page will pass a hint to the agents page via the Play flash message API

![Screenshot from 2022-03-21 13-24-25](https://user-images.githubusercontent.com/95688374/159305014-fc1063c6-0c8b-47a6-aff8-6ee67bc4699f.png)

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed 
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
