### PR TITLE
Sign out does not need to be authed

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/home/SignOutController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/home/SignOutController.scala
@@ -16,30 +16,31 @@
 
 package uk.gov.hmrc.plasticpackagingtax.returns.controllers.home
 
-import javax.inject.Inject
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
-import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthAction
 import uk.gov.hmrc.plasticpackagingtax.returns.views.html.home.session_timed_out
 import uk.gov.hmrc.plasticpackagingtax.returns.views.model.SignOutReason
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
+import javax.inject.Inject
 import scala.concurrent.Future
 
 class SignOutController @Inject() (
-  authenticate: AuthAction,
   appConfig: AppConfig,
   sessionTimedOut: session_timed_out,
   mcc: MessagesControllerComponents
 ) extends FrontendController(mcc) with I18nSupport {
 
   def signOut(signOutReason: SignOutReason): Action[AnyContent] =
-    authenticate { _ =>
+    Action.async { implicit request =>
       signOutReason match {
         case SignOutReason.SessionTimeout =>
-          Redirect(routes.SignOutController.sessionTimeoutSignedOut()).withNewSession
-        case SignOutReason.UserAction => Redirect(appConfig.exitSurveyUrl).withNewSession
+          Future.successful(
+            Redirect(routes.SignOutController.sessionTimeoutSignedOut()).withNewSession
+          )
+        case SignOutReason.UserAction =>
+          Future.successful(Redirect(appConfig.exitSurveyUrl).withNewSession)
       }
     }
 

--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ lazy val scoverageSettings: Seq[Setting[_]] = Seq(
                                    ".*(BuildInfo|Routes|Options).*",
                                    "logger.*\\(.*\\)"
   ).mkString(";"),
-  coverageMinimum := 94.0,
+  coverageMinimum := 93.0,
   coverageFailOnMinimum := true,
   coverageHighlighting := true,
   parallelExecution in Test := false

--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ lazy val scoverageSettings: Seq[Setting[_]] = Seq(
                                    ".*(BuildInfo|Routes|Options).*",
                                    "logger.*\\(.*\\)"
   ).mkString(";"),
-  coverageMinimum := 93.0,
+  coverageMinimum := 94.0,
   coverageFailOnMinimum := true,
   coverageHighlighting := true,
   parallelExecution in Test := false

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/home/SignOutControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/home/SignOutControllerSpec.scala
@@ -31,7 +31,7 @@ class SignOutControllerSpec extends ControllerSpec {
 
   private val mcc                = stubMessagesControllerComponents()
   private val sessionTimeoutPage = mock[session_timed_out]
-  private val controller         = new SignOutController(mockAuthAction, config, sessionTimeoutPage, mcc)
+  private val controller         = new SignOutController(config, sessionTimeoutPage, mcc)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -85,16 +85,15 @@ class SignOutControllerSpec extends ControllerSpec {
       }
     }
 
-    "throw exception" when {
+    "create new session" when {
 
       "unauthorised user hits sign out url" in {
 
         unAuthorizedUser()
 
-        val result = controller.signOut(SignOutReason.UserAction)(getRequest())
+        val result = controller.signOut(SignOutReason.UserAction)(getRequest("keyA" -> "valueA"))
 
-        intercept[RuntimeException](status(result))
-
+        session(result).get("keyA") shouldBe None
       }
     }
   }
@@ -148,19 +147,6 @@ class SignOutControllerSpec extends ControllerSpec {
         val result = controller.sessionTimeoutSignedOut()(getRequest())
 
         status(result) mustBe OK
-      }
-    }
-
-    "throws exception" when {
-
-      "unauthorised user hits session timeout url" in {
-
-        unAuthorizedUser()
-
-        val result = controller.signOut(SignOutReason.SessionTimeout)(getRequest())
-
-        intercept[RuntimeException](status(result))
-
       }
     }
   }


### PR DESCRIPTION
### Description of Work carried through

Removes auth from the sign out end point on Returns.
This is consistent with Registration (but that's a weak argument which I'v e cherry picked) 

This allows agents who do not meet the enrolment predicate for accessing the actual journeys to gracefully give up and exit the platform from the returns UI.

Sign out appears to be an idempotent operation with no side effects.
Permitting this is deem safer that trying to create a special case auth action just for sign out.


#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [ ] `sbt scalafmt test:scalafmt` was executed 
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
