### PR TITLE
Credential strength requirement is Strong or you're an agent

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAction.scala
@@ -189,7 +189,7 @@ class AuthActionImpl @Inject() (
       ).withDelegatedAuthRule("ppt-auth")
     }.getOrElse {
       Enrolment(pptEnrolmentKey)
-    }.and(CredentialStrength(CredentialStrength.strong))
+    }.and(acceptableCredentialStrength)
 
 }
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAgentAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAgentAction.scala
@@ -50,7 +50,7 @@ class AuthAgentActionImpl @Inject() (
 
     val authorisation = authTimer.time()
 
-    authorised(AffinityGroup.Agent.and(CredentialStrength(CredentialStrength.strong)))
+    authorised(AffinityGroup.Agent.and(acceptableCredentialStrength))
       .retrieve(authData) {
         case credentials ~ name ~ email ~ externalId ~ internalId ~ affinityGroup ~ allEnrolments ~ agentCode ~
             confidenceLevel ~ authNino ~ saUtr ~ dateOfBirth ~ agentInformation ~ groupIdentifier ~

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthCheckAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthCheckAction.scala
@@ -52,7 +52,7 @@ class AuthCheckActionImpl @Inject() (
 
     val authorisation = authTimer.time()
 
-    authorised(CredentialStrength(CredentialStrength.strong))
+    authorised(acceptableCredentialStrength)
       .retrieve(authData) {
         case credentials ~ name ~ email ~ externalId ~ internalId ~ affinityGroup ~ allEnrolments ~ agentCode ~
             confidenceLevel ~ authNino ~ saUtr ~ dateOfBirth ~ agentInformation ~ groupIdentifier ~

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/CommonAuth.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/CommonAuth.scala
@@ -16,10 +16,10 @@
 
 package uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions
 
-import play.api.mvc.Results.Redirect
 import play.api.mvc.{Result, Results}
-import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.credentials
+import uk.gov.hmrc.auth.core.authorise.Predicate
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
+import uk.gov.hmrc.auth.core.{AffinityGroup, CredentialStrength}
 import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
 
 trait CommonAuth {
@@ -30,6 +30,15 @@ trait CommonAuth {
     credentials and name and email and externalId and internalId and affinityGroup and allEnrolments and
       agentCode and confidenceLevel and nino and saUtr and dateOfBirth and agentInformation and groupIdentifier and
       credentialRole and mdtpInformation and itmpName and itmpDateOfBirth and itmpAddress and credentialStrength and loginTimes
+
+  protected def acceptableCredentialStrength: Predicate = {
+    val strongCredentials = CredentialStrength(CredentialStrength.strong)
+    // Agents are allowed to use weak credentials
+    // The order of this clause is important if we wish to preserve the MFA uplift of non agents.
+    // If an auth OR clause evaluates to false, the auth AlternateAuthPredicate with response with an exception
+    // matching the last clause it evaluated. Strong credentials needs to be the last clause if we want to catch it
+    AffinityGroup.Agent.or(strongCredentials)
+  }
 
   protected def redirectToSignin[A]: Result =
     Results.Redirect(appConfig.loginUrl, Map("continue" -> Seq(appConfig.loginContinueUrl)))

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/base/MockAuthAction.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/base/MockAuthAction.scala
@@ -77,7 +77,7 @@ trait MockAuthAction extends MockitoSugar with MetricsMocks {
 
   // format: off
   def authorizedUser(user: SignedInUser = exampleUser, requiredPredicate: Predicate = Enrolment("HMRC-PPT-ORG").
-    and(CredentialStrength(CredentialStrength.strong))): Unit = {
+    and(AffinityGroup.Agent.or(CredentialStrength(CredentialStrength.strong)))): Unit = {
     when(
       mockAuthConnector.authorise(
         ArgumentMatchers.eq(requiredPredicate),

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/base/unit/ControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/base/unit/ControllerSpec.scala
@@ -27,6 +27,7 @@ import play.api.test.CSRFTokenHelper.CSRFRequest
 import play.api.test.Helpers.contentAsString
 import play.api.test.{DefaultAwaitTimeout, FakeRequest}
 import play.twirl.api.Html
+import uk.gov.hmrc.auth.core.{AffinityGroup, CredentialStrength}
 import uk.gov.hmrc.plasticpackagingtax.returns.base.PptTestData.pptEnrolment
 import uk.gov.hmrc.plasticpackagingtax.returns.base.{MetricsMocks, MockAuthAction, PptTestData}
 import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
@@ -111,6 +112,9 @@ trait ControllerSpec
       f.setAccessible(true)
       a + (f.getName -> getValue(f, cc))
     }.toList
+
+  protected val expectedAcceptableCredentialsPredicate =
+    AffinityGroup.Agent.or(CredentialStrength(CredentialStrength.strong))
 
   private def getValue(field: Field, cc: AnyRef): String =
     field.get(cc) match {

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthActionSpec.scala
@@ -21,7 +21,6 @@ import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import play.api.mvc.{Headers, Results}
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.{
-  CredentialStrength,
   Enrolment,
   IncorrectCredentialStrength,
   InternalError,
@@ -93,10 +92,11 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
 
     "process request when an authorised client identifier is seen on an agents session" in {
       val agent = PptTestData.newAgent("456")
+
       val agentDelegatedAuthPredicate =
         Enrolment("HMRC-PPT-ORG").withIdentifier(pptEnrolmentIdentifierName,
                                                  "XMPPT0000000123"
-        ).withDelegatedAuthRule("ppt-auth").and(CredentialStrength(CredentialStrength.strong))
+        ).withDelegatedAuthRule("ppt-auth").and(expectedAcceptableCredentialsPredicate)
       authorizedUser(agent, requiredPredicate = agentDelegatedAuthPredicate)
       await(
         createAuthAction().invokeBlock(authRequest(Headers(), agent, Some("XMPPT0000000123")),

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAgentSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthAgentSpec.scala
@@ -46,10 +46,10 @@ class AuthAgentSpec extends ControllerSpec with MetricsMocks {
   "Auth Agent Action" should {
 
     "time calls to authorisation" in {
-      val user = PptTestData.newAgent("123")
+      val user = PptTestData.newAgent()
       authorizedUser(user,
                      requiredPredicate =
-                       AffinityGroup.Agent.and(CredentialStrength(CredentialStrength.strong))
+                       AffinityGroup.Agent.and(expectedAcceptableCredentialsPredicate)
       )
 
       val result =
@@ -58,10 +58,10 @@ class AuthAgentSpec extends ControllerSpec with MetricsMocks {
     }
 
     "process request when signed in user has agent affinity" in {
-      val user = PptTestData.newAgent("123")
+      val user = PptTestData.newAgent()
       authorizedUser(user,
                      requiredPredicate =
-                       AffinityGroup.Agent.and(CredentialStrength(CredentialStrength.strong))
+                       AffinityGroup.Agent.and(expectedAcceptableCredentialsPredicate)
       )
 
       await(

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthCheckSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/actions/AuthCheckSpec.scala
@@ -48,7 +48,7 @@ class AuthCheckSpec extends ControllerSpec with MetricsMocks {
       val user = PptTestData.newUser()
       authorizedUser(user,
                      requiredPredicate =
-                       AffinityGroup.Agent.and(CredentialStrength(CredentialStrength.strong))
+                       AffinityGroup.Agent.and(expectedAcceptableCredentialsPredicate)
       )
 
       val result =
@@ -60,7 +60,7 @@ class AuthCheckSpec extends ControllerSpec with MetricsMocks {
       val user = PptTestData.newUser()
       authorizedUser(user,
                      requiredPredicate =
-                       AffinityGroup.Agent.and(CredentialStrength(CredentialStrength.strong))
+                       AffinityGroup.Agent.and(expectedAcceptableCredentialsPredicate)
       )
 
       await(

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/agents/AgentsControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/agents/AgentsControllerSpec.scala
@@ -24,7 +24,7 @@ import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{await, redirectLocation, status, stubMessagesControllerComponents}
 import play.twirl.api.HtmlFormat
-import uk.gov.hmrc.auth.core.{AffinityGroup, CredentialStrength}
+import uk.gov.hmrc.auth.core.AffinityGroup
 import uk.gov.hmrc.plasticpackagingtax.returns.base.PptTestData
 import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.ControllerSpec
 import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthAgentActionImpl
@@ -57,7 +57,7 @@ class AgentsControllerSpec extends ControllerSpec {
         val agent = PptTestData.newAgent("456")
         authorizedUser(agent,
                        requiredPredicate =
-                         AffinityGroup.Agent.and(CredentialStrength(CredentialStrength.strong))
+                         AffinityGroup.Agent.and(expectedAcceptableCredentialsPredicate)
         )
 
         val result = controller.displayPage()(getRequest())

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/home/UnauthorisedControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/home/UnauthorisedControllerSpec.scala
@@ -22,12 +22,11 @@ import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
-import uk.gov.hmrc.auth.core.CredentialStrength
 import uk.gov.hmrc.plasticpackagingtax.returns.base.PptTestData
 import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.ControllerSpec
 import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthCheckActionImpl
-import uk.gov.hmrc.plasticpackagingtax.returns.views.html.home.unauthorised
 import uk.gov.hmrc.plasticpackagingtax.returns.controllers.agents.{routes => agentRoutes}
+import uk.gov.hmrc.plasticpackagingtax.returns.views.html.home.unauthorised
 
 class UnauthorisedControllerSpec extends ControllerSpec {
 
@@ -53,7 +52,6 @@ class UnauthorisedControllerSpec extends ControllerSpec {
   }
 
   "Unauthorised controller" should {
-
     "show the unauthorised page" when {
       "display page method is invoked" in {
         val result = controller.unauthorised()(getRequest())
@@ -62,7 +60,7 @@ class UnauthorisedControllerSpec extends ControllerSpec {
       }
 
       "enrolments page is invoked with by a signed in user" in {
-        authorizedUser(requiredPredicate = CredentialStrength(CredentialStrength.strong))
+        authorizedUser(requiredPredicate = expectedAcceptableCredentialsPredicate)
 
         val result = controller.notEnrolled()(getRequest())
 
@@ -73,9 +71,7 @@ class UnauthorisedControllerSpec extends ControllerSpec {
     "redirect to the agents landing page" when {
       "an agent lands on the not enrolled page after attempt to auth" in {
         val agent = PptTestData.newAgent("456")
-        authorizedUser(user = agent,
-                       requiredPredicate = CredentialStrength(CredentialStrength.strong)
-        )
+        authorizedUser(user = agent, requiredPredicate = expectedAcceptableCredentialsPredicate)
 
         val result = controller.notEnrolled()(getRequest())
 
@@ -86,9 +82,7 @@ class UnauthorisedControllerSpec extends ControllerSpec {
       "flashing a client PPT identifier not authorised is an agent set an identifier and still ended up on the not enrolled page" in {
         // This is a strong indication that the client PPT identifier is either unregistered or the client has not setup a delegated authorisation for this agent
         val agent = PptTestData.newAgent("456")
-        authorizedUser(user = agent,
-                       requiredPredicate = CredentialStrength(CredentialStrength.strong)
-        )
+        authorizedUser(user = agent, requiredPredicate = expectedAcceptableCredentialsPredicate)
 
         val requestWithClientIdentifierSet =
           FakeRequest().withSession(("clientPPT", "XMPTT0000000001"))

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/ConfirmationViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/ConfirmationViewSpec.scala
@@ -20,8 +20,6 @@ import org.scalatest.matchers.must.Matchers
 import play.api.mvc.Flash
 import play.twirl.api.Html
 import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.UnitViewSpec
-import uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.{routes => homeRoutes}
-import uk.gov.hmrc.plasticpackagingtax.returns.controllers.returns.{routes => returnRoutes}
 import uk.gov.hmrc.plasticpackagingtax.returns.models.response.FlashKeys
 import uk.gov.hmrc.plasticpackagingtax.returns.views.html.returns.confirmation_page
 import uk.gov.hmrc.plasticpackagingtax.returns.views.tags.ViewTest


### PR DESCRIPTION
Allows agents with weak credentials to access the service while preserving the MFA uplift behaviour for normal users.

### Description of Work carried through

Brief description of what/why/how.

#### Check list 
 - [ ] `./precheck` was executed (Integration/Component/Unit tests)
 - [ ] `sbt scalafmt test:scalafmt` was executed 
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
