### PR TITLE
PPTP-1867 : Delete Successfully Submitted Tax Returns

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/confirmation_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/returns/confirmation_page.scala.html
@@ -16,15 +16,12 @@
 
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.model.Title
 @import uk.gov.hmrc.plasticpackagingtax.returns.models.response.FlashKeys
-@import uk.gov.hmrc.plasticpackagingtax.returns.views.html.components.bulletListNavigation
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.html.components.paragraphBody
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.html.components.link
 @import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
-@import uk.gov.hmrc.plasticpackagingtax.returns.controllers.returns.{routes => returnsRoutes}
 @import uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.{routes => homeRoutes}
 @import uk.gov.hmrc.plasticpackagingtax.returns.views.html.main_template
-@import uk.gov.hmrc.plasticpackagingtax.returns.models.request.JourneyRequest
-@import uk.gov.hmrc.plasticpackagingtax.returns.views.utils.ViewUtils
+@import uk.gov.hmrc.plasticpackagingtax.returns.models.request.AuthenticatedRequest
 
 @this(
     govukLayout: main_template,
@@ -35,7 +32,7 @@
     appConfig: AppConfig
 )
 
-@()(implicit request: JourneyRequest[_], messages: Messages, flash: Flash)
+@()(implicit request: AuthenticatedRequest[_], messages: Messages, flash: Flash)
 
 @govukLayout(title = Title("returns.confirmationPage.title")) {
 


### PR DESCRIPTION
We only have a regular AuthenticatedRequest when displaying the return submission confirmation page (as the temporary TaxReturn is now deleted). Since we have commented out sections which appear to need details from the submitted return we might need to make a call to pick up the submitted return from EIS/ETMP before displaying this page and passing this TaxReturn as a parameter to the page - we can fix this if and when it is needed.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed 
 - [ ] Required Environment Config has been amended/added - N/A
 - [ ] Links to dependencies have been included (BE/FE work) - N/A
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave - N/A
