### PR TITLE
PPTP-1725 : Detect Deregistered Accounts

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/connectors/SubscriptionConnector.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/connectors/SubscriptionConnector.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.plasticpackagingtax.returns.connectors
 import com.kenshoo.play.metrics.Metrics
 import play.api.Logger
 import uk.gov.hmrc.http.HttpReads.Implicits.readFromJson
-import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, UpstreamErrorResponse}
 import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
 import uk.gov.hmrc.plasticpackagingtax.returns.models.subscription.subscriptionDisplay.SubscriptionDisplayResponse
 import uk.gov.hmrc.plasticpackagingtax.returns.models.subscription.subscriptionUpdate.{
@@ -50,13 +50,6 @@ class SubscriptionConnector @Inject() (
           response
       }
       .andThen { case _ => timer.stop() }
-      .recover {
-        case exception: Exception =>
-          throw DownstreamServiceError(
-            s"Failed to retrieve subscription details for PPTReference: [$pptReferenceNumber], error: [${exception.getMessage}]",
-            exception
-          )
-      }
   }
 
   def update(pptReferenceNumber: String, updateRequest: SubscriptionUpdateRequest)(implicit

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/deregistration/DeregisteredController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/deregistration/DeregisteredController.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.returns.controllers.deregistration
+
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.returns.views.html.deregistration.deregistered_page
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class DeregisteredController @Inject() (
+  authenticate: AuthAction,
+  mcc: MessagesControllerComponents,
+  page: deregistered_page
+)(implicit ec: ExecutionContext)
+    extends FrontendController(mcc) with I18nSupport {
+
+  def displayPage: Action[AnyContent] =
+    authenticate { implicit request =>
+      Ok(page())
+    }
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/home/HomeController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/controllers/home/HomeController.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.returns.controllers.home
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.http.UpstreamErrorResponse
 import uk.gov.hmrc.plasticpackagingtax.returns.config.AppConfig
 import uk.gov.hmrc.plasticpackagingtax.returns.connectors.{
   FinancialsConnector,
@@ -25,6 +26,9 @@ import uk.gov.hmrc.plasticpackagingtax.returns.connectors.{
   SubscriptionConnector
 }
 import uk.gov.hmrc.plasticpackagingtax.returns.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.returns.controllers.deregistration.{
+  routes => deregistrationRoutes
+}
 import uk.gov.hmrc.plasticpackagingtax.returns.views.html.home.home_page
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -38,7 +42,7 @@ class HomeController @Inject() (
   obligationsConnector: ObligationsConnector,
   appConfig: AppConfig,
   mcc: MessagesControllerComponents,
-  page: home_page
+  homePage: home_page
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 
@@ -47,22 +51,28 @@ class HomeController @Inject() (
       val pptReference =
         request.enrolmentId.getOrElse(throw new IllegalStateException("no enrolmentId"))
 
-      for {
-        subscription <- subscriptionConnector.get(pptReference)
-        paymentStatement <- financialsConnector.getPaymentStatement(pptReference).map(
-          response => Some(response.paymentStatement())
-        ).recoverWith { case _: Exception => Future(None) }
-        obligations <- obligationsConnector.get(pptReference).map(
-          response => Some(response)
-        ).recoverWith { case _ => Future(None) }
-      } yield Ok(
-        page(subscription,
-             obligations,
-             paymentStatement,
-             appConfig.pptCompleteReturnGuidanceUrl,
-             pptReference
-        )
-      )
+      subscriptionConnector.get(pptReference).flatMap(
+        subscription =>
+          for {
+            paymentStatement <- financialsConnector.getPaymentStatement(pptReference).map(
+              response => Some(response.paymentStatement())
+            ).recoverWith { case _: Exception => Future(None) }
+            obligations <- obligationsConnector.get(pptReference).map(
+              response => Some(response)
+            ).recoverWith { case _ => Future(None) }
+          } yield Ok(
+            homePage(subscription,
+                     obligations,
+                     paymentStatement,
+                     appConfig.pptCompleteReturnGuidanceUrl,
+                     pptReference
+            )
+          )
+      ).recover {
+        case httpEx: UpstreamErrorResponse if httpEx.statusCode == 404 =>
+          Redirect(deregistrationRoutes.DeregisteredController.displayPage())
+        case ex: Throwable => throw ex
+      }
 
     }
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/deregistration/deregistered_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/deregistration/deregistered_page.scala.html
@@ -1,0 +1,32 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.plasticpackagingtax.returns.views.html.main_template
+@import uk.gov.hmrc.plasticpackagingtax.returns.views.model.Title
+@import uk.gov.hmrc.plasticpackagingtax.returns.views.html.components._
+
+@this(
+        govukLayout: main_template,
+        pageTitle: pageTitle,
+)
+
+@()(implicit request: Request[_], messages: Messages)
+
+@govukLayout(title = Title("returns.deregistered.title")) {
+
+    @pageTitle(messages("returns.deregistered.title"))
+
+}

--- a/conf/home.routes
+++ b/conf/home.routes
@@ -13,3 +13,5 @@ GET        /we-sign-you-out         uk.gov.hmrc.plasticpackagingtax.returns.cont
 
 GET        /user-unauthorised       uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.UnauthorisedController.unauthorised()
 GET        /not-enrolled       uk.gov.hmrc.plasticpackagingtax.returns.controllers.home.UnauthorisedController.notEnrolled()
+
+GET        /deregistered-account    uk.gov.hmrc.plasticpackagingtax.returns.controllers.deregistration.DeregisteredController.displayPage()

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -283,3 +283,5 @@ subscription.primaryContactDetails.name.error.format = Name format is not suppor
 returns.submitted.title = View submitted returns
 returns.submitted.none = You have not submitted any returns yet.
 returns.submitted.link = Return to your Plastic Packaging Tax account
+
+returns.deregistered.title = You deregistered this account from Plastic Packaging Tax

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/base/unit/MockSubscriptionConnector.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/base/unit/MockSubscriptionConnector.scala
@@ -49,6 +49,11 @@ trait MockSubscriptionConnector extends MockitoSugar with BeforeAndAfterEach {
     when(mockSubscriptionConnector.get(any[String])(any()))
       .thenThrow(DownstreamServiceError("some error", new Exception("some error")))
 
+  def mockGetSubscriptionFailure(
+    ex: Exception
+  ): OngoingStubbing[Future[SubscriptionDisplayResponse]] =
+    when(mockSubscriptionConnector.get(any[String])(any())).thenReturn(Future.failed(ex))
+
   def mockUpdateSubscription(
     dataToReturn: SubscriptionUpdateResponse
   ): OngoingStubbing[Future[SubscriptionUpdateResponse]] =

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/connectors/SubscriptionConnectorSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/connectors/SubscriptionConnectorSpec.scala
@@ -71,13 +71,13 @@ class SubscriptionConnectorSpec extends ConnectorISpec with ScalaFutures with Ei
       }
     }
 
-    "throws exception" when {
+    "throw exception" when {
 
       "service returns non success status code" in {
         val pptReference = UUID.randomUUID().toString
         givenGetSubscriptionEndpointReturns(Status.BAD_REQUEST, pptReference)
 
-        intercept[DownstreamServiceError] {
+        intercept[Exception] {
           await(connector.get(pptReference))
         }
       }
@@ -86,7 +86,7 @@ class SubscriptionConnectorSpec extends ConnectorISpec with ScalaFutures with Ei
         val pptReference = UUID.randomUUID().toString
         givenGetSubscriptionEndpointReturns(Status.CREATED, pptReference, "someRubbish")
 
-        intercept[DownstreamServiceError] {
+        intercept[Exception] {
           await(connector.get(pptReference))
         }
       }

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/deregistration/DeregisteredControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/controllers/deregistration/DeregisteredControllerSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.returns.controllers.deregistration
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{reset, when}
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import play.api.http.Status.{OK, SEE_OTHER}
+import play.api.test.Helpers.{await, contentAsString, redirectLocation, session, status}
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.ControllerSpec
+import uk.gov.hmrc.plasticpackagingtax.returns.views.html.deregistration.deregistered_page
+import uk.gov.hmrc.plasticpackagingtax.returns.views.html.home.session_timed_out
+import uk.gov.hmrc.plasticpackagingtax.returns.views.model.SignOutReason
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
+
+class DeregisteredControllerSpec extends ControllerSpec {
+
+  private val mcc              = stubMessagesControllerComponents()
+  private val deregisteredPage = mock[deregistered_page]
+  private val controller       = new DeregisteredController(mockAuthAction, mcc, deregisteredPage)
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    when(deregisteredPage.apply()(any(), any())).thenReturn(HtmlFormat.raw("Deregistered"))
+  }
+
+  override protected def afterEach(): Unit = {
+    reset(deregisteredPage)
+    super.afterEach()
+  }
+
+  "Deregistered Controller" should {
+    "display the deregistered page" in {
+      authorizedUser()
+
+      val resp = controller.displayPage()(getRequest())
+
+      status(resp) mustBe OK
+      contentAsString(resp) mustBe "Deregistered"
+    }
+
+    "throw an exception when user not authenticated" in {
+      unAuthorizedUser()
+
+      intercept[RuntimeException] {
+        await(controller.displayPage()(getRequest()))
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/deregistration/DeregisteredViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/deregistration/DeregisteredViewSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.returns.views.deregistration
+
+import org.jsoup.nodes.Document
+import org.scalatest.matchers.must.Matchers
+import play.api.mvc.{AnyContent, Request}
+import play.api.test.FakeRequest
+import uk.gov.hmrc.plasticpackagingtax.returns.base.unit.UnitViewSpec
+import uk.gov.hmrc.plasticpackagingtax.returns.views.html.deregistration.deregistered_page
+import uk.gov.hmrc.plasticpackagingtax.returns.views.tags.ViewTest
+import utils.FakeRequestCSRFSupport.CSRFFakeRequest
+
+@ViewTest
+class DeregisteredViewSpec extends UnitViewSpec with Matchers {
+  override implicit val request: Request[AnyContent] = FakeRequest().withCSRFToken
+
+  private val page                   = instanceOf[deregistered_page]
+  private def createView(): Document = page()(request, messages)
+
+  override def exerciseGeneratedRenderingMethods(): Unit = {
+    page.f()(request, messages)
+    page.render(request, messages)
+  }
+
+  "Deregistered View" should {
+
+    val view = createView()
+
+    "contain timeout dialog function" in {
+      containTimeoutDialogFunction(view) mustBe false
+    }
+
+    "display title" in {
+      view.getElementById("title") must containMessage("returns.deregistered.title")
+    }
+
+    "display page heading" in {
+      view.select("h1").get(0) must containMessage("returns.deregistered.title")
+    }
+
+  }
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/returns/views/home/HomePageViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/returns/views/home/HomePageViewSpec.scala
@@ -327,15 +327,9 @@ class HomePageViewSpec extends UnitViewSpec with Matchers {
   }
 
   private def checkDeregisterCard(deregister: Element) = {
-    deregister.select("h3").text() must include(
-      messages("account.homePage.card.deregister.link")
-    )
-    deregister.select("p").text() mustBe messages(
-      "account.homePage.card.deregister.body"
-    )
-    deregister.select("a").first() must haveHref(
-      appConfig.pptRegistrationDeregisterUrl
-    )
+    deregister.select("h3").text() must include(messages("account.homePage.card.deregister.link"))
+    deregister.select("p").text() mustBe messages("account.homePage.card.deregister.body")
+    deregister.select("a").first() must haveHref(appConfig.pptRegistrationDeregisterUrl)
   }
 
   "get obligations fails" should {


### PR DESCRIPTION
We assume that a 404 (NOT_FOUND) response when attempting to get details of a user's associated PPT subscription means that they have been successfully deregistered. It is believed to be unlikely that a 404 be returned in any other scenario.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed 
 - [ ] Required Environment Config has been amended/added - N/A
 - [ ] Links to dependencies have been included (BE/FE work) - N/A
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave
