### PR TITLE
PPTP-1911: Fix missing manage registration link when de-reg feature disabled

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/returns/views/home/home_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/returns/views/home/home_page.scala.html
@@ -122,7 +122,9 @@
 
 @managementCards = {
     @entityManagementCards
-    @deregister
+    @if(appConfig.isDeRegistrationFeatureEnabled) {
+        @deregister
+    }
 }
 
 @returnsLine1 = @{
@@ -203,10 +205,8 @@
 
     <h2 class="govuk-heading-m">@messages("account.homePage.manage.ppt.account.header")</h2>
 
-    @if(appConfig.isDeRegistrationFeatureEnabled) {
-        <div class="govuk-grid-row govuk-!-margin-top-4">
-            @managementCards
-        </div>
-    }
+    <div class="govuk-grid-row govuk-!-margin-top-4">
+        @managementCards
+    </div>
 }
 


### PR DESCRIPTION
### Description of Work carried through

Fix missing manage registration link when de-reg feature disabled

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed 
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
