### PR TITLE
PPTP-1237 - Adding Welsh translations

### DIFF
--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -11,7 +11,7 @@ account.homePage.card.makeReturn.line1.singleOverdue = Your return for {0} is ov
 account.homePage.card.makeReturn.line1.none = You have no returns to submit.
 account.homePage.card.makeReturn.line2.due = You must submit your return for {0} between {1} and {2}.
 account.homePage.card.makeReturn.line3.createLink = Submit return
-account.homePage.card.makeReturn.guidance.link = Find out how to complete a return (opens in new tab)
+account.homePage.card.makeReturn.guidance.link = Rhagor o wybodaeth am sut i lenwi’ch Ffurflen Dreth (yn agor tab newydd)
 account.homePage.card.makeReturn.returnDates.link = Dyddiadau Ffurflenni Treth
 account.homePage.card.makeReturn.failure = We cannot display tax return details.
 

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -1,1 +1,43 @@
-#page left deliberately blank for Welsh translations
+service.name=Cofrestru ar gyfer y Dreth Deunydd Pacio Plastig
+title.format={0} - {1} - GOV.UK
+
+account.homePage.title = Eich cyfrif Treth Deunydd Pacio Plastig
+account.homePage.registrationNumber = Rhif cofrestru ar gyfer y Dreth Deunydd Pacio Plastig: {0}
+account.homePage.organisation.group = {0} (representative organisation for group)
+
+account.homePage.card.makeReturn.header = Ffurflenni Treth
+account.homePage.card.makeReturn.line1.multipleOverdue = You have {0} returns overdue.
+account.homePage.card.makeReturn.line1.singleOverdue = Your return for {0} is overdue.
+account.homePage.card.makeReturn.line1.none = You have no returns to submit.
+account.homePage.card.makeReturn.line2.due = You must submit your return for {0} between {1} and {2}.
+account.homePage.card.makeReturn.line3.createLink = Submit return
+account.homePage.card.makeReturn.guidance.link = Find out how to complete a return (opens in new tab)
+account.homePage.card.makeReturn.returnDates.link = Dyddiadau Ffurflenni Treth
+account.homePage.card.makeReturn.failure = We cannot display tax return details.
+
+account.homePage.card.payments.header = Taliadau
+account.homePage.card.payments.nothingOutstanding = Nid oes gennych dreth i’w thalu.
+account.homePage.card.payments.inCredit = You are {0} in credit.
+account.homePage.card.payments.debitDue = You owe {0}. You must pay by {1}.
+account.homePage.card.payments.overDue = You owe {0}. This payment is overdue.
+account.homePage.card.payments.debitAndOverDue = You owe {0}. This includes {1} which is overdue.
+account.homePage.card.payments.error = We cannot display payment details.
+
+account.homePage.manage.ppt.account.header = Rheoli’ch cyfrif
+account.homePage.card.registration.details.1.link.single = Eich manylion cofrestru
+account.homePage.card.registration.details.1.link.group = Manylion yr aelod cynrychiadol
+account.homePage.card.registration.details.1.link.partnership = Manylion y bartneriaeth
+account.homePage.card.registration.details.1.body = Bwrw golwg dros y manylion cyswllt a’u newid
+account.homePage.card.registration.details.2.link.group = Manylion aelodau’r grŵp
+account.homePage.card.registration.details.2.link.partnership = Manylion y partneriaid
+account.homePage.card.registration.details.2.body.group = Bwrw golwg dros y manylion cyswllt a’u newid, ac ychwanegu neu dynnu aelodau o’r grŵp.
+account.homePage.card.registration.details.2.body.partnership = Bwrw golwg dros y manylion cyswllt a’u newid, ac ychwanegu neu dynnu partneriaid.
+
+account.homePage.card.deregister.link = Deregister from Plastic Packaging Tax
+account.homePage.card.deregister.body = Cancel your Plastic Packaging Tax registration.
+
+unauthorised.heading = You must be registered to use this service
+unauthorised.paragraph.1 = You need to {0} to use this service
+unauthorised.paragraph.1.link = register for Plastic Packaging Tax
+unauthorised.paragraph.2 = Visit the {0} for more information.
+unauthorised.paragraph.2.link = Plastic Packaging Tax guidance


### PR DESCRIPTION
### Description of Work carried through

Adding Welsh translations and placeholder fallback text.

/account

Before: 
![welsh_account](https://user-images.githubusercontent.com/45816181/161053876-f8d10a92-292d-4e68-a418-bae26f00d09d.png)

After:
![welsh_account_as live](https://user-images.githubusercontent.com/45816181/161053778-e6366743-3269-4c99-b689-fa985a57d3a5.png)


/account/not-enrolled

Before:
![welsh_not-enrolled](https://user-images.githubusercontent.com/45816181/161053944-ca55e1e8-6c8a-4d0e-8fc1-55bb6d66a2a2.png)

After (Go-Live):
![welsh_not-enrolled_v2](https://user-images.githubusercontent.com/45816181/161053962-35485e50-8b17-4c33-b217-a67a0aa34dc1.png)


#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed 
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
