### PR TITLE
PPTP-2384: Fix all Axe and VNU HTML validation errors

### DIFF
--- a/app/assets/stylesheets/_returns.scss
+++ b/app/assets/stylesheets/_returns.scss
@@ -23,6 +23,11 @@
   margin-bottom: 10px;
 }
 
+.govuk-summary-list__value {
+ overflow-wrap: inherit;
+ word-wrap: inherit;
+}
+
 /***************************************
  ***********  Mobile Styling  **********
  ***************************************/

--- a/app/views/amends/AmendManufacturedPlasticPackagingView.scala.html
+++ b/app/views/amends/AmendManufacturedPlasticPackagingView.scala.html
@@ -59,7 +59,6 @@
             .asNumeric()
             .withWidth(Fixed10)
             .withHint(Hint(content = HtmlContent(hintContent)))
-            .describedBy("test described by part")
         )
 
         @govukButton(

--- a/app/views/returns/ReturnsCheckYourAnswersView.scala.html
+++ b/app/views/returns/ReturnsCheckYourAnswersView.scala.html
@@ -88,8 +88,11 @@
 }
 
 @changeLink(linkTextShortKey: String, url: String) = @{
+
+    val linkId = linkTextShortKey.split("\\.")(0)
+
     paragraph(
-        content = link(id = "", text = messages(toLongKey(linkTextShortKey)), call = Call("GET", url)),
+        content = link(id=linkId, text = messages(toLongKey(linkTextShortKey)), call = Call("GET", url)),
     )
 }
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,7 +4,7 @@ object AppDependencies {
   import play.core.PlayVersion
 
   val compile = Seq(play.sbt.PlayImport.ws,
-                    "uk.gov.hmrc"       %% "play-frontend-hmrc"            % "1.31.0-play-28",
+                    "uk.gov.hmrc"       %% "play-frontend-hmrc"            % "3.21.0-play-28",
                     "uk.gov.hmrc"       %% "play-conditional-form-mapping" % "1.9.0-play-28",
                     "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"    % "5.18.0",
                     "uk.gov.hmrc"       %% "play-language"                 % "5.1.0-play-28",


### PR DESCRIPTION
Note I've put some styling in because since upgrading play-frontend-govuk the value in the check answers screen is breaking by character and displaying the text vertically 🫤