### PR TITLE
PPTP-2448: Reduce key column width on check answers pages

### DIFF
--- a/app/viewmodels/checkAnswers/ViewReturnSummaryViewModel.scala
+++ b/app/viewmodels/checkAnswers/ViewReturnSummaryViewModel.scala
@@ -29,7 +29,7 @@ import java.time.format.DateTimeFormatter
 
 final case class Field(key: String, value: String, bold: Boolean = false, big: Boolean = false){
   def classes: String =
-    Seq("govuk-!-width-three-quarters",
+    Seq("govuk-!-width-one-half",
       if (big) "govuk-body-l" else "govuk-body-m",
       if (bold) "govuk-!-font-weight-bold" else "govuk-!-font-weight-regular",
     ).mkString(" ")

--- a/app/viewmodels/checkAnswers/returns/ManufacturedPlasticPackagingSummary.scala
+++ b/app/viewmodels/checkAnswers/returns/ManufacturedPlasticPackagingSummary.scala
@@ -31,7 +31,7 @@ class ManufacturedPlasticPackagingSummary (key: String) extends SummaryViewModel
       answer =>
         val value = if (answer) "site.yes" else "site.no"
 
-        SummaryListRow(key = Key(key, classes="govuk-!-width-three-quarters"),
+        SummaryListRow(key = Key(key, classes="govuk-!-width-one-half"),
           value = Value(value),
           actions = Some(Actions(items = Seq(
             ActionItem(

--- a/app/views/returns/ReturnsCheckYourAnswersView.scala.html
+++ b/app/views/returns/ReturnsCheckYourAnswersView.scala.html
@@ -45,14 +45,14 @@
 
 @summaryRow(key: String, value: String, valueClasses: String = "") = @{
     SummaryListRow(
-        key = Key(key, classes = s"govuk-!-font-weight-regular ${InputWidth.ThreeQuarters}"),
+        key = Key(key, classes = s"govuk-!-font-weight-regular ${InputWidth.OneHalf}"),
         value = Value(value, classes = valueClasses)
     )
 }
 
 @summaryRowWithWideValue(shortKey: String, value: String) = @{
     val text = messages(toLongKey(shortKey))
-    summaryRow(text, value)
+    summaryRow(text, value, "govuk-table__cell--numeric")
 }
 
 @summaryRowFromString(shortKey: String, value: String) = @{

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,7 +4,7 @@ object AppDependencies {
   import play.core.PlayVersion
 
   val compile = Seq(play.sbt.PlayImport.ws,
-                    "uk.gov.hmrc"       %% "play-frontend-hmrc"            % "3.21.0-play-28",
+                    "uk.gov.hmrc"       %% "play-frontend-hmrc"            % "3.22.0-play-28",
                     "uk.gov.hmrc"       %% "play-conditional-form-mapping" % "1.9.0-play-28",
                     "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"    % "5.18.0",
                     "uk.gov.hmrc"       %% "play-language"                 % "5.1.0-play-28",


### PR DESCRIPTION
As agreed with design team.

1. Reduce the risk of overflow of column 2 into column 3 on check answers pages
2. Right align business info on final return summary