### PR TITLE
PPTP-2760 - Updating CYA character encoding

### DIFF
--- a/app/forms/changeGroupLead/MainContactJobTitleFormProvider.scala
+++ b/app/forms/changeGroupLead/MainContactJobTitleFormProvider.scala
@@ -34,7 +34,7 @@ class MainContactJobTitleFormProvider{
 }
 object MainContactJobTitleFormProvider {
   private val MaxLength = 155
-  private val AllowedCharacterRegex = "^[A-z ]*$"
+  private val AllowedCharacterRegex = "^[A-Za-z ]*$"
   val EmptyError = "mainContactJobTitle.error.required"
   val LengthError = "mainContactJobTitle.error.length"
   val InvalidError = "mainContactJobTitle.error.invalid"

--- a/app/forms/changeGroupLead/MainContactNameFormProvider.scala
+++ b/app/forms/changeGroupLead/MainContactNameFormProvider.scala
@@ -36,7 +36,7 @@ class MainContactNameFormProvider {
 
 object MainContactNameFormProvider {
   private val MaxLength = 160
-  private val AllowedCharacterRegex = "^[A-z '.-]*$"
+  private val AllowedCharacterRegex = "^[A-Za-z '.-]*$"
   val EmptyError = "mainContactName.error.required"
   val LengthError = "mainContactName.error.length"
   val InvalidError = "mainContactName.error.invalid"

--- a/app/viewmodels/checkAnswers/changeGroupLead/MainContactNameSummary.scala
+++ b/app/viewmodels/checkAnswers/changeGroupLead/MainContactNameSummary.scala
@@ -35,7 +35,7 @@ object MainContactNameSummary extends SummaryViewModel {
 
         SummaryListRowViewModel(
           key     = "newGroupLeadCheckYourAnswers.contact.name.key",
-          value   = ValueViewModel(HtmlFormat.escape(answer).toString),
+          value   = ValueViewModel(answer),
           actions = Seq(
             ActionItemViewModel("site.change", routes.MainContactNameController.onPageLoad(CheckMode).url)
               .withVisuallyHiddenText(messages("newGroupLeadCheckYourAnswers.contact.name.key"))


### PR DESCRIPTION
### Description of Work carried through

- Updating regex pattern to block back ticks
- Removing html format escape to allow apostrophe to be displayed in cya

Note - Tested manually that js can not be executed in CYA page, had to hack the code to even allow the required chars to do that.