### PR TITLE
Override black-on-blue text in research banner to work-around a11y is…

### DIFF
--- a/app/assets/stylesheets/_returns.scss
+++ b/app/assets/stylesheets/_returns.scss
@@ -97,6 +97,7 @@ td.govuk-table__cell.row-border {
   }
 
   &__title {
+    color: govuk-colour("white") !important;
     @include govuk-responsive-margin(1, "bottom");
   }
 


### PR DESCRIPTION
…sue (contrast)

